### PR TITLE
Add Java->simple_components->Blockly path

### DIFF
--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -146,6 +146,13 @@ Blockly.ComponentDatabase = function() {
 
   /**
    * Maps names of option lists to OptionLists.
+   * 
+   * This map is used to de-duplicate duplicated optionList info provided via
+   * the simple_components.json file, so that every option is represented
+   * exactly once in the component database. Everything that needs to reference
+   * an optionList should do so via the getOptionList function using the option
+   * lists's key. This field is used in conjunction with the processOptionList
+   * method to achieve this behavior.
    * @type {Object.<string, Option>}
    */
   this.optionLists_ = {};
@@ -455,10 +462,17 @@ Blockly.ComponentDatabase.prototype.processHelper = function(helper) {
 /**
  * Processes data defining an OptionList (from simple_components.json) and
  * returns a HelperKey associated with the OptionList.
+ * 
+ * This function is used in conjunction with the optionLists_ field to remove
+ * duplicate optionList data provided via the simple_components.json file.
  * @param {!Object} data The data defining the OptionList.
  * @return {!HelperKey} The key associated with the OptionList.
  */
 Blockly.ComponentDatabase.prototype.processOptionList = function(data) {
+  // The first time an optionList is encountered its data is inserted into the
+  // optionLists_ map and its data is cached. All future calls to
+  // processOptionList do not process the option list, and just return
+  // a HelperKey which can be used to retrieve information from this map.
   if (!this.optionLists_[data.key]) {
     var options = [];
     for (var i = 0, option; option = data.options[i]; i++) {

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -126,6 +126,7 @@ Option = function() {};
  * @property {!string} className
  * @property {!string} tag
  * @property {!string} defaultOpt
+ * @property {!string} underlyingType
  * @property {!Array.<!Option>} options
  */
 OptionList = function() {};
@@ -412,7 +413,6 @@ Blockly.ComponentDatabase.prototype.populateTypes = function(componentInfos) {
       });
     }
   }
-  console.log(this.optionLists_);
 };
 
 /**
@@ -469,6 +469,7 @@ Blockly.ComponentDatabase.prototype.processOptionList = function(data) {
       className: data.className,
       tag: data.tag,
       defaultOpt: data.defaultOpt,
+      underlyingType: data.underlyingType,
       options: options
     };
   }

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -38,20 +38,41 @@ Blockly.PROPERTY_READWRITEABLE = 3;
 ComponentInfo = function() {};
 
 /**
+ * @typedef HelperKey
+ * @type {object}
+ * @property {!string} type
+ * @property {!string} key
+ */
+HelperKey = function() {};
+
+/**
  * @typedef ParameterDescriptor
  * @type {object}
  * @property {!string} name
  * @property {!type} type
+ * @property {HelperKey} helperKey
  */
 ParameterDescriptor = function() {};
 
 /**
- * @typedef {{name: !string, description: !string, deprecated: ?boolean, parameters: !ParameterDescriptor[]}}
+ * @typedef {{
+ *            name: !string,
+ *            description: !string,
+ *            deprecated: ?boolean,
+ *            parameters: !ParameterDescriptor[]
+ *          }}
  */
 EventDescriptor = function() {};
 
 /**
- * @typedef {{name: !string, description: !string, deprecated: ?boolean, parameters: !ParameterDescriptor[], returnType: ?string}}
+ * @typedef {{
+ *            name: !string,
+ *            description: !string,
+ *            deprecated: ?boolean,
+ *            parameters: !ParameterDescriptor[],
+ *            returnType: ?string
+ *            returnHelperKey: !HelperKey
+ *          }}
  */
 MethodDescriptor = function() {};
 
@@ -61,6 +82,7 @@ MethodDescriptor = function() {};
  * @property {!string} name
  * @property {!string} description
  * @property {!string} type
+ * @property {HelperKey} helperKey
  * @property {!string} rw
  * @property {?boolean} deprecated
  */
@@ -89,6 +111,26 @@ ComponentTypeDescriptor = function() {};
 ComponentInstanceDescriptor = function() {};
 
 /**
+ * @typedef Option
+ * @type {object}
+ * @property {!string} name
+ * @property {!string} value
+ * @property {!string} description
+ * @property {?boolean} deprecated
+ */
+Option = function() {};
+
+/**
+ * @typedef OptionList
+ * @type {object}
+ * @property {!string} className
+ * @property {!string} tag
+ * @property {!string} defaultOpt
+ * @property {!Array.<!Option>} options
+ */
+OptionList = function() {};
+
+/**
  * Database for component type information and instances.
  * @constructor
  */
@@ -100,6 +142,12 @@ Blockly.ComponentDatabase = function() {
   // For migration of old projects that are name based rather than uid based.
   /** @type {Object.<string, string>} */
   this.instanceNameUid_ = {};
+
+  /**
+   * Maps names of option lists to OptionLists.
+   * @type {Object.<string, Option>}
+   */
+  this.optionLists_ = {};
 
   // Internationalization support
   this.i18nComponentTypes_ = {};
@@ -315,7 +363,7 @@ Blockly.ComponentDatabase.prototype.populateTypes = function(componentInfos) {
         event['deprecated'] = JSON.parse(event['deprecated']);
       }
       if (event['parameters'] === undefined) {
-        event['parameters'] = event['params'];
+        event['parameters'] = this.processParameters(event['params']);
         delete event['params'];
       }
       info.eventDictionary[event.name] = event;
@@ -325,8 +373,11 @@ Blockly.ComponentDatabase.prototype.populateTypes = function(componentInfos) {
         method['deprecated'] = JSON.parse(method['deprecated']);
       }
       if (method['parameters'] === undefined) {
-        method['parameters'] = method['params'];
+        method['parameters'] = this.processParameters(method['params']);
         delete method['params'];
+      }
+      if (method['helper']) {
+        method['returnHelperKey'] = this.processHelper(method['helper']);
       }
       info.methodDictionary[method.name] = method;
     }
@@ -335,6 +386,9 @@ Blockly.ComponentDatabase.prototype.populateTypes = function(componentInfos) {
       if (typeof property['deprecated'] === 'string') {
         property['deprecated'] = JSON.parse(property['deprecated']);
         if (property['deprecated']) continue;
+      }
+      if (property['helper']) {
+        property['helperKey'] = this.processHelper(property['helper']);
       }
       if (property['rw'] == 'read-write') {
         property.mutability = Blockly.PROPERTY_READWRITEABLE;
@@ -358,7 +412,80 @@ Blockly.ComponentDatabase.prototype.populateTypes = function(componentInfos) {
       });
     }
   }
+  console.log(this.optionLists_);
 };
+
+/**
+ * Processes the given array of parameters (from simple_components.json, not
+ * Parameters) and returns an array of Parameters.
+ * @param {!Array.<!Object>} paramData An array of data from
+ *     simple_components.json defining the parameters.
+ * @return {!Array.<!Parameter>} An array of parameters.
+ */
+Blockly.ComponentDatabase.prototype.processParameters = function(paramData) {
+  params = [];
+  for (var i = 0, datum; datum = paramData[i]; i++) {
+    var param = {};
+    param.name = datum.name;
+    param.type = datum.type;
+    param.helperKey = this.processHelper(datum.helper);
+    params.push(param);
+  }
+  return params;
+}
+
+/**
+ * Processes a helper (from simple_components.json) and returns a HelperKey if
+ * possible.
+ * @param {Object} helper The (possibly null) helper definition.
+ * @return {HelperKey} The helper key associated with the helper (if it is
+ *     possible) to create one.
+ */
+Blockly.ComponentDatabase.prototype.processHelper = function(helper) {
+  if (!helper) {
+    return null;
+  }
+  switch (helper.type) {
+    case "OPTION_LIST":
+      return this.processOptionList(helper.data);
+  }
+  return null;
+}
+
+/**
+ * Processes data defining an OptionList (from simple_components.json) and
+ * returns a HelperKey associated with the OptionList.
+ * @param {!Object} data The data defining the OptionList.
+ * @return {!HelperKey} The key associated with the OptionList.
+ */
+Blockly.ComponentDatabase.prototype.processOptionList = function(data) {
+  if (!this.optionLists_[data.key]) {
+    var options = [];
+    for (var i = 0, option; option = data.options[i]; i++) {
+      options[i] = this.processOption(option);
+    }
+
+    this.optionLists_[data.key] = {
+      className: data.className,
+      tag: data.tag,
+      defaultOpt: data.defaultOpt,
+      options: options
+    };
+  }
+  return {
+    type: "OPTION_LIST",
+    key: data.key
+  };
+}
+
+Blockly.ComponentDatabase.prototype.processOption = function(option) {
+  return {
+    name: option.name,
+    value: option.value,
+    description: option.description,
+    deprecated: option.deprecated == "true"
+  };
+}
 
 Blockly.ComponentDatabase.PROPDESC = /PropertyDescriptions$/;
 Blockly.ComponentDatabase.METHODDESC = /MethodDescrptions$/;
@@ -502,6 +629,16 @@ Blockly.ComponentDatabase.prototype.getGetterNamesForType = function(typeName) {
   }
   return null;
 };
+
+/**
+ * Returns the OptionList associated with the given key.
+ * @param {!string} key The dictionary key for the OptionList.
+ * @return {OptionList} The associated option list, or undefined if one is not
+ *     found.
+ */
+Blockly.ComponentDatabase.prototype.getOptionList = function(key) {
+  return this.optionLists_[key];
+}
 
 /**
  * Get the internationalized string for the given component type.

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -76,7 +76,7 @@ import javax.tools.FileObject;
  *   “methods”: [
  *     { "name": "METHOD-NAME",
  *       "description": "DESCRIPTION",
- *       "returnType": "RETURN-TYPE",
+ *       "returnType": "YAIL-TYPE",
  *       "helper": {
  *         "type": HELPER-TYPE,
  *         "data": { ARBITRARY-DATA } 
@@ -94,6 +94,19 @@ import javax.tools.FileObject;
  *   ],
  *   ("assets": ["FILENAME",*])?
  * }
+ * 
+ * A note on helper "ARBITRARY-DATA". The structure given above outlines a system where helper data
+ * is duplicated every time that helper is used by a feature of a Component. Ideally this would
+ * not be necessary and helper data could be stored in some kind of dictionary structure. The issue
+ * is that this must export an array of objects to be compatible with extension .aia files which
+ * have already been released, and adding more dictionaries or arrays to this structure would
+ * require it to export an /object/ not an /array/. As such the simplest solution is to simply
+ * duplicate data related to the helpers.
+ * 
+ * It may make sense in the future to revist this choice, but making this decision now would only
+ * make it harder to support a more "lean" concept of data in the future, as we would still have to
+ * deal with .aia files that use this duplicated format. So it is probably best to continue
+ * duplicating data where necessary in the future.
  *
  * @author lizlooney@google.com (Liz Looney)
  * @author sharon@google.com (Sharon Perl) - added events, methods, non-designer

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
@@ -419,37 +420,26 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
    */
   private void outputOptionList(String key, StringBuilder sb) {
     OptionList optList = optionLists.get(key);
-    sb.append("      \"className\": \"");
-    sb.append(optList.getClassName());
-    sb.append("\",\n");
-    sb.append("      \"key\": \"");
-    sb.append(key);
-    sb.append("\",\n");
-    sb.append("      \"tag\": \"");
-    sb.append(optList.getTagName());
-    sb.append("\",\n");
-    sb.append("      \"defaultOpt\": \"");
-    sb.append(optList.getDefault());
-    sb.append("\",\n");
-    sb.append("      \"underlyingType\": \"");
-    sb.append(optList.getUnderlyingType().toString());
-    sb.append("\",\n");
-    sb.append("      \"options\": [\n");
-    String separator = "";
+
+    StringJoiner optsJoiner = new StringJoiner(",\n", "[\n", "\n      ]\n");
     for (Option opt : optList.asCollection()) {
-      sb.append(separator);
-      sb.append("        { \"name\": \"");
-      sb.append(opt.name);
-      sb.append("\", \"value\": \"");
-      sb.append(opt.getValue());
-      sb.append("\", \"description\": ");
-      sb.append(formatDescription(opt.getDescription()));
-      sb.append(", \"deprecated\": \"");
-      sb.append(opt.isDeprecated());
-      sb.append("\" }");
-      separator = ",\n";
+      StringJoiner optJoiner = new StringJoiner(", ", "       { ", " }");
+      optJoiner.add("\"name\": \"" +  opt.name + "\"")
+          .add("\"value\": \"" +  opt.getValue() + "\"")
+          .add("\"description\": " + formatDescription(opt.getDescription()))
+          .add("\"deprecated\": \"" + opt.isDeprecated() + "\"");
+      optsJoiner.add(optJoiner.toString());
     }
-    sb.append("\n      ]\n");
+
+    StringJoiner sj = new StringJoiner(",\n      ", "      ", "");
+    sj.add("\"className\": \"" + optList.getClassName() + "\"")
+        .add("\"key\": \"" + key + "\"")
+        .add("\"tag\": \"" + optList.getTagName() + "\"")
+        .add("\"defaultOpt\": \"" + optList.getDefault() + "\"")
+        .add("\"underlyingType\": \"" + optList.getUnderlyingType().toString() + "\"")
+        .add("\"options\": " + optsJoiner.toString());
+
+    sb.append(sj.toString());
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -418,6 +418,9 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("      \"defaultOpt\": \"");
     sb.append(optList.getDefault());
     sb.append("\",\n");
+    sb.append("      \"underlyingType\": \"");
+    sb.append(optList.getUnderlyingType().toString());
+    sb.append("\",\n");
     sb.append("      \"options\": [\n");
     String separator = "";
     for (Option opt : optList.asCollection()) {


### PR DESCRIPTION
### Description

Depends on #3 

Modifies the ComponentDescriptorGenerator to add OptionList info to the simple_components.json file. The component_database (Blockly side) then reads that json to populate a new `optionLists_` dictionary. It also adds helper keys to all of the associated properties, methods, and parameters.

### Testing

Added logging and tested that Direction, MapFeature, and ScreenAnimation were all properly read and populated. Also tested that OptionsLists defined by extensions get properly populated.

### Recommended Method for Reviewing
1. Review the changes to the [component descriptor generator](https://github.com/BeksOmega/appinventor-sources/pull/4/files?file-filters%5B%5D=.java#diff-0baff13a84be099f9cdfd928caefc21e). Check that the changes create the expected output (given at the top of the file).
2. Review the changes to the [component database](https://github.com/BeksOmega/appinventor-sources/pull/4/files#diff-7f92aaa2f89110a614c406da22dc510c).