### PR TITLE
Add dropdown blocks & update component input checks

### DIFF
--- a/appinventor/blocklyeditor/ploverConfig.js
+++ b/appinventor/blocklyeditor/ploverConfig.js
@@ -131,6 +131,7 @@
     "./src/warningHandler.js",
     "./src/field_procedure.js",
     "./src/field_textblockinput.js",
+    "./src/field_invalid_dropdown.js",
     "./src/warningIndicator.js",
     "./src/exportBlocksImage.js",
     "./src/flydown.js",
@@ -167,6 +168,7 @@
     './src/blocks/colors.js',
     './src/blocks/components.js',
     './src/blocks/dictionaries.js',
+    './src/blocks/helpers.js',
 
     //generator files
     "./src/generators/yail.js",
@@ -180,6 +182,7 @@
     "./src/generators/yail/variables.js",
     "./src/generators/yail/procedures.js",
     "./src/generators/yail/dictionaries.js",
+    './src/generators/yail/helpers.js',
 
     // Repl
     "./src/replmgr.js",

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -1207,7 +1207,9 @@ Blockly.Blocks.component_set_get = {
     }
 
     // Aka if this is a setter. We don't want blockly to think properties that
-    //    return strings but accept options actually return options.
+    // return strings but accept options actually return options. Once we add
+    // support for sanitizing returned values to their enum types, this will
+    // change.
     if (inputOrOutput == Blockly.Blocks.Utilities.INPUT) {
       var helperType = Blockly.Blocks.Utilities
           .helperKeyToBlocklyType(property.helperKey, this);

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -626,7 +626,8 @@ Blockly.Blocks.component_method = {
     if(!this.isGeneric) {
       container.setAttribute('instance_name', this.instanceName);//instance name not needed
     }
-    if (!this.isGeneric && this.typeName == "Clock" && Blockly.ComponentBlock.isClockMethodName(this.methodName)) {
+    if (!this.isGeneric && this.typeName == "Clock" &&
+        Blockly.ComponentBlock.isClockMethodName(this.methodName)) {
       var timeUnit = this.getFieldValue('TIME_UNIT');
       container.setAttribute('method_name', 'Add' + timeUnit);
       container.setAttribute('timeUnit', timeUnit);
@@ -742,11 +743,15 @@ Blockly.Blocks.component_method = {
     }
     oldInputValues.splice(0, oldInputValues.length - params.length);
     for (var i = 0, param; param = params[i]; i++) {
-      var newInput = this.appendValueInput("ARG" + i).appendField(componentDb.getInternationalizedParameterName(param.name));
-      newInput.setAlign(Blockly.ALIGN_RIGHT);
-      var blockyType = Blockly.Blocks.Utilities.YailTypeToBlocklyType(param.type,Blockly.Blocks.Utilities.INPUT);
-      newInput.connection.setCheck(blockyType);
-      if (oldInputValues[i] && newInput.connection) {
+      var name = componentDb.getInternationalizedParameterName(param.name);
+      var check = this.getParamBlocklyType(param);
+
+      var input = this.appendValueInput("ARG" + i)
+          .appendField(name)
+          .setAlign(Blockly.ALIGN_RIGHT)
+          .setCheck(check);
+
+      if (oldInputValues[i] && input.connection) {
         Blockly.Mutator.reconnect(oldInputValues[i].outputConnection, this, 'ARG' + i);
       }
     }
@@ -802,7 +807,29 @@ Blockly.Blocks.component_method = {
    * @returns {(MethodDescriptor|undefined)}
    */
   getMethodTypeObject : function() {
-    return this.getTopWorkspace().getComponentDatabase().getMethodForType(this.typeName, this.methodName);
+    return this.getTopWorkspace().getComponentDatabase()
+        .getMethodForType(this.typeName, this.methodName);
+  },
+
+  getParamBlocklyType : function(param) {
+    var check = [];
+
+    var blocklyType = Blockly.Blocks.Utilities.YailTypeToBlocklyType(
+        param.type, Blockly.Blocks.Utilities.Input);
+    if (blocklyType) {
+      if (Array.isArray(blocklyType)) {
+        check = blocklyType;
+      } else {
+        check.push(blocklyType);
+      }
+    }
+
+    var helperType = Blockly.Blocks.Utilities
+        .helperKeyToBlocklyType(param.helperKey, this);
+    if (helperType && helperType != blocklyType) {
+      check.push(helperType);
+    }
+    return !check.length ? null : check;
   },
 
   /**
@@ -905,8 +932,8 @@ Blockly.Blocks.component_method = {
               modifiedParameters = true;
               break; // invalid input or connection
             }
-            var blockyType = Blockly.Blocks.Utilities.YailTypeToBlocklyType(param.type,Blockly.Blocks.Utilities.INPUT);
-            input.connection.setCheck(blockyType); // correct type
+            var check = this.getParamBlocklyType(param);
+            input.setCheck(check);
             found = true;
             break;
           }
@@ -1146,15 +1173,14 @@ Blockly.Blocks.component_set_get = {
   },
 
   setTypeCheck : function() {
-
     var inputOrOutput = Blockly.Blocks.Utilities.OUTPUT;
     if(this.setOrGet == "set") {
       inputOrOutput = Blockly.Blocks.Utilities.INPUT;
     }
 
     var newType = this.getPropertyBlocklyType(this.propertyName,inputOrOutput);
-    // this will disconnect the block if the new outputType doesn't match the
-    // socket the block is plugged into
+    // This will disconnect the block if the new outputType doesn't match the
+    // socket the block is plugged into.
     if(this.setOrGet == "get") {
       this.outputConnection.setCheck(newType);
     } else {
@@ -1163,12 +1189,36 @@ Blockly.Blocks.component_set_get = {
   },
 
   getPropertyBlocklyType : function(propertyName,inputOrOutput) {
-    var yailType = "any"; // necessary for undefined propertyObject
-    if (this.getPropertyObject(propertyName)) {
-      yailType = this.getPropertyObject(propertyName).type;
+    var check = [];
+
+    var yailType = "any"; // Necessary for undefined propertyObject.
+    var property = this.getPropertyObject(propertyName);
+    if (property) {
+      yailType = property.type;
     }
-    return Blockly.Blocks.Utilities.YailTypeToBlocklyType(yailType,inputOrOutput);
+    var blocklyType = Blockly.Blocks.Utilities
+        .YailTypeToBlocklyType(yailType, inputOrOutput);
+    if (blocklyType) {
+      if (Array.isArray(blocklyType)) {
+        check = blocklyType;
+      } else {
+        check.push(blocklyType);
+      }
+    }
+
+    // Aka if this is a setter. We don't want blockly to think properties that
+    //    return strings but accept options actually return options.
+    if (inputOrOutput == Blockly.Blocks.Utilities.INPUT) {
+      var helperType = Blockly.Blocks.Utilities
+          .helperKeyToBlocklyType(property.helperKey, this);
+      if (helperType && helperType != blocklyType) {
+          check.push(helperType);
+      }
+    }
+
+    return !check.length ? null : check;
   },
+
   getPropertyDropDownList : function() {
     var componentDb = this.getTopWorkspace().getComponentDatabase();
     var dropDownList = [];

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -1,0 +1,95 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2013-2014 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+
+/**
+ * @license
+ * @fileoverview Helper block definitions. These are created based on the
+ *     component database, and are meant to be connected to component
+ *     method/setter inputs to make coding faster for users.
+ */
+
+'use strict';
+
+goog.provide('Blockly.Blocks.helpers');
+
+goog.require('Blockly.Blocks.Utilities');
+
+Blockly.COLOUR_HELPERS = "#BF4343";
+
+Blockly.Blocks['helpers_dropdown'] = {
+  init: function() {
+    /**
+     * The key to the OptionList associated with this block.
+     * @private
+     */
+    this.key_ = "";
+
+    // TODO: Do we want to do anything for tooltips on this guy?
+    this.setColour(Blockly.COLOUR_HELPERS);
+    // Everything else gets hander by domToMutaiton.
+  },
+ 
+  mutationToDom: function() {
+    var mutation = document.createElement('mutation');
+    mutation.setAttribute('key', this.key_);
+    return mutation;
+  },
+
+  domToMutation: function(xml) {
+    this.key_ = xml.getAttribute('key');
+    var type = Blockly.Blocks.Utilities.helperKeyToBlocklyType(
+      { type: 'OPTION_LIST', key: this.key_ }, this);
+
+    var optionList = this.getTopWorkspace().getComponentDatabase()
+        .getOptionList(this.key_);
+
+    var dropdown = new Blockly.FieldInvalidDropdown(
+        this.getValidOptions(), this.getInvalidOptions());
+
+    this.setOutput(true, type);
+    this.appendDummyInput()
+        .appendField(optionList.tag)
+        .appendField(dropdown, 'OPTION');
+    
+    this.setFieldValue(optionList.defaultOpt, 'OPTION');
+  },
+
+  /**
+   * Returns a list of tuples defining the valid dropdown values. The first
+   * element in the tuple is the human readable name. The second element is the
+   * language neutral value.
+   */
+  getValidOptions: function() {
+    var optionList = this.getTopWorkspace().getComponentDatabase()
+        .getOptionList(this.key_);
+    var options = [];
+    for (var i = 0, option; option = optionList.options[i]; i++) {
+      // TODO: First will eventually be the translated name.
+      if (!option.deprecated) {
+        options.push([option.name, option.name]);
+      }
+    }
+    return options;
+  },
+
+  /**
+   * Returns a list of tuples defining the /invalid/ dropdown values. The first
+   * element in the tuple is the human readable name. The second element is the
+   * language neutral value.
+   */
+  getInvalidOptions: function() {
+    var optionList = this.getTopWorkspace().getComponentDatabase()
+        .getOptionList(this.key_);
+    var options = [];
+    for (var i = 0, option; option = optionList.options[i]; i++) {
+      // TODO: First will eventually be the translated name.
+      if (option.deprecated) {
+        options.push([option.name, option.name]);
+      }
+    }
+    return options;
+  }
+}

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -26,10 +26,8 @@ Blockly.Blocks['helpers_dropdown'] = {
      * @private
      */
     this.key_ = "";
-
-    // TODO: Do we want to do anything for tooltips on this guy?
     this.setColour(Blockly.COLOUR_HELPERS);
-    // Everything else gets hander by domToMutaiton.
+    // Everything else gets handled by domToMutaiton.
   },
  
   mutationToDom: function() {
@@ -49,6 +47,10 @@ Blockly.Blocks['helpers_dropdown'] = {
     var dropdown = new Blockly.FieldInvalidDropdown(
         this.getValidOptions(), this.getInvalidOptions());
 
+    // Setting the output check to be the OptionList type only allows this block
+    // to connect to inputs which expect its specific type of enum. Currently
+    // this is only used for Blockly connection checks, as no output types are
+    // encoded in Yail.
     this.setOutput(true, type);
     this.appendDummyInput()
         .appendField(optionList.tag)

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -44,8 +44,14 @@ Blockly.Blocks.Utilities.OUTPUT = 1;
 Blockly.Blocks.Utilities.INPUT = 0;
 
 Blockly.Blocks.Utilities.YailTypeToBlocklyType = function(yail,inputOrOutput) {
+    if (yail.indexOf('Enum') != -1) {
+      return yail;
+    }
 
-    var inputOrOutputName = (inputOrOutput == Blockly.Blocks.Utilities.OUTPUT ? "output" : "input");
+    // TODO: Might be better to just swith OUTPUT and INPUT to strings. Would
+    //   require investigation.
+    var inputOrOutputName = (inputOrOutput == Blockly.Blocks.Utilities.OUTPUT) ?
+        "output" : "input";
     var bType = Blockly.Blocks.Utilities.YailTypeToBlocklyTypeMap[yail][inputOrOutputName];
 
     if (bType !== null || yail == 'any') {
@@ -54,6 +60,40 @@ Blockly.Blocks.Utilities.YailTypeToBlocklyType = function(yail,inputOrOutput) {
         throw new Error("Unknown Yail type: " + yail + " -- YailTypeToBlocklyType");
     }
 };
+
+/**
+ * Returns the blockly type associated with the given helper key, or null if
+ * there is not one.
+ * @param {!HelperKey} helperKey The helper key to find the equivalent blockly
+ *     type of.
+ * @param {!Blockly.Block} block The block which we will apply the type to. Used
+ *     to access the component database etc.
+ * @return {string?} The correct string representation of the type, or null.
+ */
+Blockly.Blocks.Utilities.helperKeyToBlocklyType = function(helperKey, block) {
+  if (!helperKey) {
+    return null;
+  }
+  var utils = Blockly.Blocks.Utilities;
+  switch (helperKey.type) {
+    case "OPTION_LIST":
+      return utils.optionListKeyToBlocklyType(helperKey.key, block);
+  }
+  return null;
+}
+
+/**
+ * Returns the blockly type associated with the given option list helper key.
+ * @param {HelperKey} key The key to find the equivalent blockly type of.
+ * @param {!Blockly.Block} block The block which we will apply the type to. Used
+ *     to access the component database etc.
+ * @return {!string} The correct string representation of the type.
+ */
+Blockly.Blocks.Utilities.optionListKeyToBlocklyType = function(key, block) {
+  var optionList = block.getTopWorkspace().getComponentDatabase()
+      .getOptionList(key);
+  return optionList.className + 'Enum';
+}
 
 
 // Blockly doesn't wrap tooltips, so these can get too wide.  We'll create our own tooltip setter

--- a/appinventor/blocklyeditor/src/field_invalid_dropdown.js
+++ b/appinventor/blocklyeditor/src/field_invalid_dropdown.js
@@ -1,0 +1,150 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright © 2013-2016 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+'use strict';
+
+goog.provide('AI.Blockly.FieldInvalidDropdown');
+
+goog.require('AI.Events');
+goog.require('Blockly.FieldDropdown');
+
+/**
+ * Dropdown field that allows you to display invalid options. Options that are
+ * not available (invalid) are displayed, and the block is marked as a
+ * badBlock().
+ * @param {(!Array.<!Array>|!Function)} menuGenerator A non-empty array of
+ *     options for a dropdown list, or a function which generates these options.
+ * @param {!Array.<!Array>} opt_invalidOptions A list of invalid options with
+ *     identically structure to the menuGenerator options list. These options
+ *     will not be available in the dropdown, but the correct human-readable
+ *     values will be displayed if they get some other way (eg via xml).
+ * @param {Function=} opt_validator A change listener that is called when a new
+ *     option is selected from the dropdown.
+ */
+Blockly.FieldInvalidDropdown = function(
+    menuGenerator, opt_invalidOptions, opt_validator
+) {
+  Blockly.FieldInvalidDropdown.superClass_.constructor.call(
+      this, menuGenerator, opt_validator);
+  this.invalidOptions_ = opt_invalidOptions || [];
+}
+goog.inherits(Blockly.FieldInvalidDropdown, Blockly.FieldDropdown);
+
+/**
+ * Adds a change listener to the workspace that makes sure the current value is
+ * valid whenever we switch between workspaces.
+ */
+Blockly.FieldInvalidDropdown.prototype.init = function() {
+  Blockly.FieldInvalidDropdown.superClass_.init.call(this);
+  this.sourceBlock_.workspace.addChangeListener(function(e) {
+    if (e.type == AI.Events.SCREEN_SWITCH) {
+      // Make sure value is still valid.
+      this.setValue(this.getValue());
+    }
+  }.bind(this))
+}
+
+/**
+ * Displays the invalid value and marks the block this field belongs to as a
+ * badBlock();
+ * @param {string} invalidValue The invalid value / unavailable option.
+ */
+Blockly.FieldInvalidDropdown.prototype.doValueInvalid_ = function(invalidValue) {
+  this.value_ = invalidValue;
+  this.isDirty_ = true;
+  this.sourceBlock_ && this.sourceBlock_.badBlock();
+
+  this.selectedOption_ = [invalidValue, invalidValue];
+  for (var i = 0, option; (option = this.invalidOptions_[i]); i++) {
+    // Options are tuples of human-readable text and language-neutral values.
+    if (option[1] == invalidValue) {
+      this.selectedOption_ = option;
+      break;
+    }
+  }
+
+  // TODO: Remove the rest of this function after Blockly update.
+  this.text_ = this.selectedOption_[0];
+  this.size_.width = 0;
+  if (this.sourceBlock_ && this.sourceBlock_.rendered) {
+    this.sourceBlock_.render();
+    this.sourceBlock_.bumpNeighbours_();
+  }
+}
+
+/**
+ * Updates the value of this dropdown and removes badBlock() from the source
+ * block if it exists.
+ * @param {*} newValue  The value to be saved.
+ */
+Blockly.FieldInvalidDropdown.prototype.doValueUpdate_ = function(newValue) {
+  // TODO: Uncomment this after Blockly update.
+  //Blockly.FieldInvalidDropdown.superClass_.doValueUpdate_.call(this, newValue);
+  this.sourceBlock_ && this.sourceBlock_.notBadBlock();
+
+  // TODO: Remove the rest of this function after Blockly update.
+  this.value_ = newValue;
+  var options = this.getOptions_();
+  for (var i = 0, option; (option = options[i]); i++) {
+    // Options are tuples of human-readable text and language-neutral values.
+    if (option[1] == newValue) {
+      this.selectedOption_ = option;
+      break;
+    }
+  }
+  this.text_ = this.selectedOption_[0];
+  this.size_.width = 0;
+  if (this.sourceBlock_ && this.sourceBlock_.rendered) {
+    this.sourceBlock_.render();
+    this.sourceBlock_.bumpNeighbours_();
+  }
+}
+
+// TODO: Remove the rest of this file after the Blockly update.
+Blockly.FieldInvalidDropdown.prototype.setValue = function(newValue) {
+  var oldValue = this.getValue();
+  if (newValue === null) {
+    // Not a valid value to check.
+    return;
+  }
+
+  var validatedValue = this.doClassValidation_(newValue);
+  newValue = this.processValidation_(newValue, validatedValue);
+  if (newValue instanceof Error) {
+    return;
+  }
+
+  var source = this.sourceBlock_;
+  if (source && Blockly.Events.isEnabled()) {
+    Blockly.Events.fire(new Blockly.Events.Change(
+        source, 'field', this.name || null, oldValue, newValue));
+  }
+  this.doValueUpdate_(newValue);
+}
+
+Blockly.FieldInvalidDropdown.prototype.processValidation_ =
+  function(newValue, validatedValue) {
+    if (validatedValue === null) {
+      this.doValueInvalid_(newValue);
+      return Error();
+    }
+    return newValue;
+  };
+
+Blockly.FieldInvalidDropdown.prototype.doClassValidation_ = function(newValue) {
+  var isValueValid = false;
+  var options = this.getOptions_();
+  for (var i = 0, option; (option = options[i]); i++) {
+    // Options are tuples of human-readable text and language-neutral values.
+    if (option[1] == newValue) {
+      isValueValid = true;
+      break;
+    }
+  }
+  if (!isValueValid) {
+    return null;
+  }
+  return /** @type {string} */ (newValue);
+}

--- a/appinventor/blocklyeditor/src/field_invalid_dropdown.js
+++ b/appinventor/blocklyeditor/src/field_invalid_dropdown.js
@@ -19,7 +19,10 @@ goog.require('Blockly.FieldDropdown');
  * @param {!Array.<!Array>} opt_invalidOptions A list of invalid options with
  *     identically structure to the menuGenerator options list. These options
  *     will not be available in the dropdown, but the correct human-readable
- *     values will be displayed if they get some other way (eg via xml).
+ *     values will be displayed if they are set some other way (eg via xml).
+ *     If an invalid value is set and it does not exist in the set of
+ *     invalidOptions then the stringified version of that value will be
+ *     displayed.
  * @param {Function=} opt_validator A change listener that is called when a new
  *     option is selected from the dropdown.
  */
@@ -82,6 +85,8 @@ Blockly.FieldInvalidDropdown.prototype.doValueInvalid_ = function(invalidValue) 
 Blockly.FieldInvalidDropdown.prototype.doValueUpdate_ = function(newValue) {
   // TODO: Uncomment this after Blockly update.
   //Blockly.FieldInvalidDropdown.superClass_.doValueUpdate_.call(this, newValue);
+  
+  // If we get here the value is valid. Make sure the block is not marked as bad.
   this.sourceBlock_ && this.sourceBlock_.notBadBlock();
 
   // TODO: Remove the rest of this function after Blockly update.
@@ -114,6 +119,15 @@ Blockly.FieldInvalidDropdown.prototype.setValue = function(newValue) {
   newValue = this.processValidation_(newValue, validatedValue);
   if (newValue instanceof Error) {
     return;
+  }
+
+  var localValidator = this.getValidator();
+  if (localValidator) {
+    validatedValue = localValidator.call(this, newValue);
+    newValue = this.processValidation_(newValue, validatedValue);
+    if (newValue instanceof Error) {
+      return;
+    }
   }
 
   var source = this.sourceBlock_;

--- a/appinventor/blocklyeditor/src/generators/yail/helpers.js
+++ b/appinventor/blocklyeditor/src/generators/yail/helpers.js
@@ -8,8 +8,18 @@ Blockly.Yail['helpers_dropdown'] = function() {
       .getOptionList(this.key_);
   var enumConstantName = this.getFieldValue('OPTION');
 
+  // TODO: This will be used after we add abstraction.
   // See https://www.gnu.org/software/kawa/Enumerations.html
-  var code = optionList.className + ":" + enumConstantName;
+  //var code = optionList.className + ":" + enumConstantName;
+
+  var option = optionList.options.find(function(opt) {
+    return opt.name == enumConstantName;
+  });
+
+  var code = option.value;
+  if (optionList.underlyingType == "java.lang.String") {
+    code = Blockly.Yail.quote_(code);
+  } // Otherwise assume it doesn't need to be quoted.
 
   return [code, Blockly.Yail.ORDER_ATOMIC]
 }

--- a/appinventor/blocklyeditor/src/generators/yail/helpers.js
+++ b/appinventor/blocklyeditor/src/generators/yail/helpers.js
@@ -1,0 +1,15 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2013-2014 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+Blockly.Yail['helpers_dropdown'] = function() {
+  var optionList = this.workspace.getComponentDatabase()
+      .getOptionList(this.key_);
+  var enumConstantName = this.getFieldValue('OPTION');
+
+  // See https://www.gnu.org/software/kawa/Enumerations.html
+  var code = optionList.className + ":" + enumConstantName;
+
+  return [code, Blockly.Yail.ORDER_ATOMIC]
+}

--- a/appinventor/blocklyeditor/src/generators/yail/helpers.js
+++ b/appinventor/blocklyeditor/src/generators/yail/helpers.js
@@ -8,10 +8,6 @@ Blockly.Yail['helpers_dropdown'] = function() {
       .getOptionList(this.key_);
   var enumConstantName = this.getFieldValue('OPTION');
 
-  // TODO: This will be used after we add abstraction.
-  // See https://www.gnu.org/software/kawa/Enumerations.html
-  //var code = optionList.className + ":" + enumConstantName;
-
   var option = optionList.options.find(function(opt) {
     return opt.name == enumConstantName;
   });
@@ -22,4 +18,14 @@ Blockly.Yail['helpers_dropdown'] = function() {
   } // Otherwise assume it doesn't need to be quoted.
 
   return [code, Blockly.Yail.ORDER_ATOMIC]
+
+  // TODO: This will be used after we add abstraction.
+  // See https://www.gnu.org/software/kawa/Enumerations.html
+  // var code = optionList.className + ":" + enumConstantName;
+
+  // Currently we are returning the concrete values of the optionList option for
+  // easy backwards compatibility with the companion. But in the future we will
+  // return a macro which checks if the companion supports OptionLists and if
+  // it does it will return the abstract enum value. If the companion does not
+  // support OptionLists it will continue to return the concrete value.
 }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -1366,6 +1366,8 @@
   (if (and (enum? arg)
         ;; We have to trick the Kawa compiler into not open-coding "instance?"
         ;; or else we get a ClassCastException here.
+        ;; This check is necessary to make sure we treat each enum type separately.
+        ;; Eg a HorizontalAlignment is different from a VerticalAlignment.
         (apply instance? (list arg (string->symbol (string-replace-all (symbol->string type) "Enum" "")))))
       arg 
       *non-coercible-value*))
@@ -1421,7 +1423,7 @@
    ((string? arg)
     (or (padded-string->number arg) *non-coercible-value*))
    ((enum? arg)
-    (let ((val (arg:getValue)))
+    (let ((val (arg:toUnderlyingValue)))
       (if (number? val)
         val
         *non-coercible-value*)))
@@ -1454,7 +1456,7 @@
              (let ((pieces (map coerce-to-string arg)))
                (call-with-output-string (lambda (port) (display pieces port))))))
         ((enum? arg)
-          (let ((val (arg:getValue)))
+          (let ((val (arg:toUnderlyingValue)))
             (if (string? val)
               val
               *non-coercible-value*)))
@@ -1681,8 +1683,8 @@
    ;; ((and (string? x1) (string? x2))
    ;;  (equal? x1 x2))
 
-   ((and (enum? x1) (not (enum? x2))) (equal? (x1:getValue) x2))
-   ((and (not (enum? x1)) (enum? x2)) (equal? x1 (x2:getValue)))
+   ((and (enum? x1) (not (enum? x2))) (equal? (x1:toUnderlyingValue) x2))
+   ((and (not (enum? x1)) (enum? x2)) (equal? x1 (x2:toUnderlyingValue)))
 
    ;; If the x1 and x2 are not equal?, try comparing coverting x1 and x2 to numbers
    ;; and comparing them numerically

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -1431,7 +1431,9 @@
 
 (define (coerce-to-key arg)
   (cond
-   ;;; TODO: I don't understand why these values have to be coerced.
+   ;;; TODO: Beka and Lyn don't understand why these values have to be coerced.
+   ;;;   Eg if (number? arg) is true we just pass the arg to a procedure that returns
+   ;;;   arg if (number? arg) is true. So why don't we just return arg here?
    ((number? arg) (coerce-to-number arg))
    ((string? arg) (coerce-to-string arg))
    ((instance? arg com.google.appinventor.components.runtime.Component) arg)


### PR DESCRIPTION
### Description

Depends on #4 

This pull request does 4 things:
1) Modifies the blocks that represent methods and property setters so that if they represent an upgraded component they will accept either the primitive-type block (for backwards compat) or the abstracted dropdown block.

    For example the **block** associated with this method would only accept a primitive string block:
    ```
    @SimpleFunction
    public void MakeDance(String animal) { }
    ```

    This one would only accept a dropdown block:
    ```
    @SimpleFunction
    public void MakeDance(Animal animal) { }
    ```

    And this one would accept either:
    ```
    @Simplefunction
    public void MakeDance(@Options(Animal.class) String animal) { }
    ```

2) Adds a definition for the dropdown block. The block constructs itself based on its mutator which looks like the following:
    ```
    <mutation key="myKey"/>
    ```

    It uses the string key (e.g. myKey) to look up the OptionList it is associated with in the Blockly-side component_database.js

3) Modifies the runtime.scm file so that enums (which are represented by dropdown blocks) can be coerced to strings or numbers (for backwards compat). [Edit: this won't be used right now because everything is concrete, but it is best to leave it in]
4) Modifies the runtime.scm file so that enums can be compared with more primitive values (for backwards compat). [Edit: again for now this won't be used]

### Testing

If you would like to pull this pull request and test you can do the following:
1) Checkout the pull request using [github's instructions](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally).
2) Run `ant clean` and `ant` in your root App Inventor directory.
3) Run `ant installplay` while your phone is connected to your computer to load a new companion.
4) Run your local app inventor instance.
5) Create a new project and navigate to the blocks tab.
5) Open your browser's console and paste the following code:
```
Blockly.Xml.domToWorkspace(
  Blockly.Xml.textToDom(
    '<xml>' +
      '<block type="helpers_dropdown"><mutation key="Direction"/></block>' +
      '<block type="helpers_dropdown"><mutation key="ScreenAnimation"/></block>' +
      '<block type="helpers_dropdown"><mutation key="MapFeature"/></block>' +
    '</xml>'),
  Blockly.mainWorkspace);
```
6) Play around with the resulting dropdown blocks.

I tested all of the upgraded component blocks to make sure they accept both the primitive and abstract blocks. I also tested comparing their return values against the primitive and abstract blocks.

I also created some test components. One component used the upgrade method of annotations to define the dropdown blocks. Another used the new style method of using the enum as the parameter type. I did things like:
* Assigning primitive and abstract types to old-style blocks.
* Assigning abstract types to new blocks (and making sure it didn't accept primitive types)
* Attempting to assign primitive types to new-style blocks using variables (errors were properly thrown).
* Attempting to assign the incorrect abstract type to a new style block (errors were properly thrown).
* Comparing old-style returns against primitive and abstract types.

I feel pretty confident that all of the block stuff is working!

### Recommend Method for Reviewing
1) Review the [FieldInvalidDropdown](https://github.com/BeksOmega/appinventor-sources/pull/5/files?file-filters%5B%5D=.js#diff-a61ef7a00c00fadab2852fa9827eebd8).
2) Review the [utilities file](https://github.com/BeksOmega/appinventor-sources/pull/5/files?file-filters%5B%5D=.js#diff-1ac27aeae3d0c8c2f286cb805e34ca6f).
3) Review the [helper block definition](https://github.com/BeksOmega/appinventor-sources/pull/5/files?file-filters%5B%5D=.js#diff-7aa12b3497a5f408877d090b517399d8).
4) Review the [component block changes](https://github.com/BeksOmega/appinventor-sources/pull/5/files?file-filters%5B%5D=.js#diff-d759fc0ff054590505afd7fd2c809365).
5) Review the [helper block code generator](https://github.com/BeksOmega/appinventor-sources/pull/5/files?file-filters%5B%5D=.js#diff-d35c20a05deb9a8155ed1aba5cb73da0).
6) Review the changes to [runtime.scm](https://github.com/BeksOmega/appinventor-sources/pull/5/files?file-filters%5B%5D=.scm#diff-919464dac4d96743f3dd7b71efe472ec).