### PR TITLE
Add translation of dropdown blocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -40,10 +40,11 @@ Blockly.Blocks['helpers_dropdown'] = {
     this.key_ = xml.getAttribute('key');
     var type = Blockly.Blocks.Utilities.helperKeyToBlocklyType(
       { type: 'OPTION_LIST', key: this.key_ }, this);
+    this.setOutput(true, type);
 
-    var optionList = this.getTopWorkspace().getComponentDatabase()
-        .getOptionList(this.key_);
-
+    var db = this.getTopWorkspace().getComponentDatabase();
+    var optionList = db.getOptionList(this.key_);
+    var tag = db.getInternationalizedOptionListTag(optionList.tag);
     var dropdown = new Blockly.FieldInvalidDropdown(
         this.getValidOptions(), this.getInvalidOptions());
 
@@ -53,7 +54,7 @@ Blockly.Blocks['helpers_dropdown'] = {
     // encoded in Yail.
     this.setOutput(true, type);
     this.appendDummyInput()
-        .appendField(optionList.tag)
+        .appendField(tag)
         .appendField(dropdown, 'OPTION');
     
     this.setFieldValue(optionList.defaultOpt, 'OPTION');
@@ -65,13 +66,14 @@ Blockly.Blocks['helpers_dropdown'] = {
    * language neutral value.
    */
   getValidOptions: function() {
-    var optionList = this.getTopWorkspace().getComponentDatabase()
-        .getOptionList(this.key_);
+    var db = this.getTopWorkspace().getComponentDatabase();
+    var optionList = db.getOptionList(this.key_);
     var options = [];
     for (var i = 0, option; option = optionList.options[i]; i++) {
-      // TODO: First will eventually be the translated name.
+      var key = optionList.tag + option.name;
+      var i18nName = db.getInternationalizedOptionName(key, option.name);
       if (!option.deprecated) {
-        options.push([option.name, option.name]);
+        options.push([i18nName, option.name]);
       }
     }
     return options;
@@ -83,13 +85,14 @@ Blockly.Blocks['helpers_dropdown'] = {
    * language neutral value.
    */
   getInvalidOptions: function() {
-    var optionList = this.getTopWorkspace().getComponentDatabase()
-        .getOptionList(this.key_);
+    var db = this.getTopWorkspace().getComponentDatabase();
+    var optionList = db.getOptionList(this.key_);
     var options = [];
     for (var i = 0, option; option = optionList.options[i]; i++) {
-      // TODO: First will eventually be the translated name.
+      var key = optionList.tag + option.name;
+      var i18nName = db.getInternationalizedOptionName(key, option.name);
       if (option.deprecated) {
-        options.push([option.name, option.name]);
+        options.push([i18nName, option.name]);
       }
     }
     return options;

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -166,6 +166,8 @@ Blockly.ComponentDatabase = function() {
   this.i18nParamNames_ = {};
   this.i18nPropertyNames_ = {};
   this.i18nPropertyDescriptions_ = {};
+  this.i18nOptionNames_ = {};
+  this.i18nOptionListTags_ = {};
 };
 
 /**
@@ -513,28 +515,43 @@ Blockly.ComponentDatabase.EVENTDESC = /EventDescriptions$/;
 Blockly.ComponentDatabase.prototype.populateTranslations = function(translations) {
   var newkey;
   for (var key in translations) {
-    if (translations.hasOwnProperty(key)) {
-      var parts = key.split('-', 2);
-      if (parts[0] === 'COMPONENT') {
-        this.i18nComponentTypes_[parts[1]] = translations[key];
-      } else if (parts[0] === 'PROPERTY') {
-        this.i18nPropertyNames_[parts[1]] = translations[key];
-      } else if (parts[0] === 'EVENT') {
-        this.i18nEventNames_[parts[1]] = translations[key];
-      } else if (parts[0] === 'METHOD') {
-        this.i18nMethodNames_[parts[1]] = translations[key];
-      } else if (parts[0] === 'PARAM') {
-        this.i18nParamNames_[parts[1]] = translations[key];
-      } else if (parts[0] === 'EVENTDESC') {
-        newkey = parts[1].replace(Blockly.ComponentDatabase.EVENTDESC, '');
-        this.i18nEventDescriptions_[parts[1]] = translations[key];
-      } else if (parts[0] === 'METHODDESC') {
-        newkey = parts[1].replace(Blockly.ComponentDatabase.METHODDESC, '');
-        this.i18nMethodDescriptions_[newkey] = translations[key];
-      } else if (parts[0] === 'PROPDESC') {
-        newkey = parts[1].replace(Blockly.ComponentDatabase.PROPDESC, '');
-        this.i18nPropertyDescriptions_[newkey] = translations[key];
-      }
+    if (!translations.hasOwnProperty(key)) {
+      continue;
+    }
+    var parts = key.split('-', 2);
+    var type = parts[0];
+    var jsKey = parts[1];
+    var translation = translations[key];
+    switch(type) {
+      case 'COMPONENT':
+        this.i18nComponentTypes_[jsKey] = translation;
+        break;
+      case 'PROPERTY':
+        this.i18nPropertyNames_[jsKey] = translation;
+        break;
+      case 'EVENT':
+        this.i18nEventNames_[jsKey] = translation;
+        break;
+      case 'METHOD':
+        this.i18nMethodNames_[jsKey] = translation;
+        break;
+      case 'PARAM':
+        this.i18nParamNames_[jsKey] = translation;
+        break;
+      case 'EVENTDESC':
+        this.i18nEventDescriptions_[jsKey] = translation;
+        break;
+      case 'METHODDESC':
+        this.i18nMethodDescriptions_[jsKey] = translation;
+        break;
+      case 'PROPDESC':
+        this.i18nPropertyDescriptions_[jsKey] = translation;
+        break;
+      case 'OPTION':
+        this.i18nOptionNames_[jsKey] = translation;
+        break;
+      case 'OPTIONLIST':
+        this.i18nOptionListTags_[jsKey] = translation;
     }
   }
 };
@@ -734,3 +751,31 @@ Blockly.ComponentDatabase.prototype.getInternationalizedPropertyName = function(
 Blockly.ComponentDatabase.prototype.getInternationalizedPropertyDescription = function(component, name, opt_default) {
   return this.i18nPropertyDescriptions_[component + '.' + name] || this.i18nPropertyDescriptions_[name] || opt_default || name;
 };
+
+/**
+ * Returns the internationalized string for the given option name.
+ * @param {string} key The tag name of the option list + the name of the option.
+ *     Used to get the internationalized name.
+ * @param {string} opt_default The default name if an internationalized one is
+ *     not found.
+ * @return {string} The localized string if available, otherwise the unlocalized
+ *     one.
+ */
+Blockly.ComponentDatabase.prototype.getInternationalizedOptionName =
+  function(key, opt_default) {
+    return this.i18nOptionNames_[key] || opt_default;
+  };
+
+/**
+ * Returns the internationalized string for the given option list tag.
+ * @param {string} name The name of the tag used to get the internationlized
+ *     version.
+ * @param {string} opt_default The default name if the internationalized name
+ *     is not available.
+ * @return {string} The localized string if available, otherwise the unlocalized
+ *     string.
+ */
+Blockly.ComponentDatabase.prototype.getInternationalizedOptionListTag =
+  function(name, opt_default) {
+    return this.i18nOptionListTags_[name] || opt_default || name;
+  }

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -552,6 +552,7 @@ Blockly.ComponentDatabase.prototype.populateTranslations = function(translations
         break;
       case 'OPTIONLIST':
         this.i18nOptionListTags_[jsKey] = translation;
+        break;
     }
   }
 };

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
@@ -293,6 +293,10 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
       computeTooltipMap(component);
       categories.add(component.getCategory());
     }
+    for (Map.Entry<String, OptionList> entry : optionLists.entrySet()) {
+      OptionList optionList = entry.getValue();
+      outputOptionListAutogen(optionList, sb);
+    }
     for (String key : collisionKeys) {
       tooltips.remove(key);
     }
@@ -337,6 +341,59 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
     writer.close();
     messager.printMessage(Kind.NOTE, "Wrote file " + src.toUri());
   }
+
+  protected void outputOptionList(OptionList optionList, StringBuilder sb) {
+    String tagName = optionList.getTagName();
+    String lowerTagName = Character.toLowerCase(tagName.charAt(0))
+        + tagName.substring(1);
+    sb.append("\n\n/* OptionList ");
+    sb.append(tagName);
+    sb.append(" */\n\n");
+
+    // Translate tag.
+    sb.append("     map.put(\"OPTIONLIST-")
+      .append(tagName)
+      .append("\", MESSAGES.")
+      .append(lowerTagName)
+      .append("OptionList());\n");
+
+    // Translate options.
+    for (Option option : optionList.asCollection()) {
+      sb.append("    map.put(\"OPTION-")
+        .append(tagName)
+        .append(option.name)
+        .append("\", MESSAGES.")
+        .append(lowerTagName)
+        .append(option.name)
+        .append("Option());\n");
+    }
+  }
+
+  private void outputOptionListAutogen(OptionList optionList, StringBuilder sb) {
+    String tagName = optionList.getTagName();
+    String lowerTagName = Character.toLowerCase(tagName.charAt(0))
+        + tagName.substring(1);
+
+    sb.append("  @DefaultMessage(\"")
+      .append(sanitize(tagName))
+      .append("\")\n")
+      .append("  @Description(\"\")\n")
+      .append("  String ")
+      .append(lowerTagName)
+      .append("OptionList();\n\n");
+
+    for (Option option : optionList.asCollection()) {
+      sb.append("  @DefaultMessage(\"")
+        .append(sanitize(option.name))
+        .append("\")\n")
+        .append("  @Description(\"\")\n")
+        .append("  String ")
+        .append(lowerTagName)
+        .append(option.name)
+        .append("Option();\n\n");
+    }
+  }
+
 
   @Override
   protected void outputResults() throws IOException {
@@ -410,6 +467,10 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
       ComponentInfo component = entry.getValue();
       outputComponent(component, properties, methods, events, sb);
       categories.add(component.getCategory());
+    }
+    for (Map.Entry<String, OptionList> entry : optionLists.entrySet()) {
+      OptionList optionList = entry.getValue();
+      outputOptionList(optionList, sb);
     }
     sb.append("\n\n    /* Descriptions */\n\n");
     for (String key : tooltips.keySet()) {


### PR DESCRIPTION
### Description

Depends on #5 

This pull request adds the ability to internationalize OptionList tags and OptionList Option names.

### Testing

1. Added the following to the bottom of the OdeMessages_es_ES.properties file.
```
directionOptionList = Test1
directionNorthOption = Test2
```
2. Switched to Spanish.
3. Observed that the blocks were "properly" translated.
Spanish:
![Spanish](https://user-images.githubusercontent.com/25440652/85185641-b824d600-b249-11ea-9f36-ebffe92b2a5d.png)

English:
![English](https://user-images.githubusercontent.com/25440652/85185644-ba873000-b249-11ea-8dbd-6a26b4ef0da9.png)

### Recommended Method for Review
1. Review changes to the [component translation generator](https://github.com/BeksOmega/appinventor-sources/pull/7/files#diff-9b3399c49903798dd38a7bb414eecdde) (this generates the files which are used to populate the translations).
2. Review the [component database changes](https://github.com/BeksOmega/appinventor-sources/pull/7/files#diff-7f92aaa2f89110a614c406da22dc510c). These are primarily reorganization things (changing a giant if-else into a switch). But it did add the [getInternationalizedOptionName](https://github.com/BeksOmega/appinventor-sources/pull/7/files#diff-7f92aaa2f89110a614c406da22dc510cR749) and [getInternationalizedOptionListTag](https://github.com/BeksOmega/appinventor-sources/pull/7/files#diff-7f92aaa2f89110a614c406da22dc510cR763) functions.
3. Review changes to the [dropdown block definition](https://github.com/BeksOmega/appinventor-sources/pull/7/files#diff-7aa12b3497a5f408877d090b517399d8).