### PR TITLE
Add upgrading to dropdowns

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -520,6 +520,10 @@ public final class YoungAndroidFormUpgrader {
       // The OriginAtCenter property was added.
       srcCompVersion = 6;
     }
+    if (srcCompVersion < 7) {
+      // Direction dropdown blocks were added.
+      srcCompVersion = 7;
+    }
     return srcCompVersion;
   }
   private static int upgradeBarcodeScannerProperties(Map<String, JSONValue> componentProperties,
@@ -1034,6 +1038,11 @@ public final class YoungAndroidFormUpgrader {
       srcCompVersion = 27;
     }
 
+    if (srcCompVersion < 28) {
+      // ScreenAnimation dropdown blocks were added.
+      srcCompVersion = 28;
+    }
+
     return srcCompVersion;
   }
 
@@ -1149,6 +1158,10 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 6) {
       // The callback parameters speed and heading were added to Flung.
       srcCompVersion = 6;
+    }
+    if (srcCompVersion < 7) {
+      // Direction dropdown blocks were added.
+      srcCompVersion = 7;
     }
     return srcCompVersion;
   }

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -513,6 +513,7 @@ public class YaVersion {
   // For YOUNG_ANDROID_VERSION 207:
   // - BLOCKS_LANGUAGE_VERSION was incremented to 32
 
+  // TODO: Bump this before merge. Include notes about all upgraded components.
   public static final int YOUNG_ANDROID_VERSION = 207;
 
   // ............................... Blocks Language Version Number ...............................
@@ -676,7 +677,9 @@ public class YaVersion {
   // - Callback parameters speed and heading were added to Flung. (for all sprites)
   // For BALL_COMPONENT_VERSION 6:
   // - The CenterAtOrigin property was added
-  public static final int BALL_COMPONENT_VERSION = 6;
+  // For Ball_COMPONENT_VERSION 7:
+  // - Adds dropdown blocks for Direction.
+  public static final int BALL_COMPONENT_VERSION = 7;
 
   // For BARCODESCANNER_COMPONENT_VERSION 2:
   // -- UseExternalScanner property was added (default true)
@@ -879,7 +882,9 @@ public class YaVersion {
   // - Updated the default value of ShowListsAsJson from false -> true
   // For FORM_COMPONENT_VERSION 27:
   // - Added the Platform and PlatformVersion read-only blocks
-  public static final int FORM_COMPONENT_VERSION = 27;
+  // For FORM_COMPONENT_VERSION 28:
+  // - Adds dropdown blocks for ScreenAnimation.
+  public static final int FORM_COMPONENT_VERSION = 28;
 
   // For FUSIONTABLESCONTROL_COMPONENT_VERSION 2:
   // - The Fusiontables API was migrated from SQL to V1
@@ -937,7 +942,9 @@ public class YaVersion {
   // - The TouchUp, TouchDown, and Flung events were added. (for all sprites)
   // For IMAGESPRITE_COMPONENT_VERSION 6:
   // - Callback parameters speed and heading were added to Flung. (for all sprites)
-  public static final int IMAGESPRITE_COMPONENT_VERSION = 6;
+  // For IMAGESPRITE_COMPONENT_VERSION 7:
+  // - Adds dropdown blocks for Direction.
+  public static final int IMAGESPRITE_COMPONENT_VERSION = 7;
 
   // For LABEL_COMPONENT_VERSION 2:
   // - The Alignment property was renamed to TextAlignment.


### PR DESCRIPTION
### Description

Depends on #5

This PR adds some new upgraders to versioning.js so that we can automatically change user's constant blocks to dropdown blocks.

### Testing

I created a test project using the production ai2 editor. It included the following blocks:
![Old](https://user-images.githubusercontent.com/25440652/85233544-09ed6d80-b3bc-11ea-820b-05f7d97897ea.png)

I think passed that project to this version of ai and go these blocks:
![Upgraded](https://user-images.githubusercontent.com/25440652/85233548-0f4ab800-b3bc-11ea-8eea-b79dd081ac35.png)

Which is what was expected.

Here is the zipped .aia: [test6.zip](https://github.com/BeksOmega/appinventor-sources/files/4810153/test6.zip)

### Recommended Method for Review
1) Review the new methods in [versioning.js](https://github.com/BeksOmega/appinventor-sources/pull/8/files#diff-96198d9d4cd1f3db6c38212f6ae28745R960)
2) Review the rest of the code, which upgrades the Ball, ImageSprite, and Form (Screen) components. 