### PR TITLE
Add typeblock support for dropdown blocks

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -110,7 +110,7 @@ Blockly.Blocks['helpers_dropdown'] = {
         var i18nName = db.getInternationalizedOptionName(key, option.name);
         tb.push({
           // TODO: This doesn't handle rtl langs, anyway to fix that?
-          translatedName: tag + ": " + i18nName,
+          translatedName: tag + i18nName,
           mutatorAttributes: {
             key: optionList.tag,
             value: option.name

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -57,7 +57,8 @@ Blockly.Blocks['helpers_dropdown'] = {
         .appendField(tag)
         .appendField(dropdown, 'OPTION');
     
-    this.setFieldValue(optionList.defaultOpt, 'OPTION');
+    var value = xml.getAttribute('value') || optionList.defaultOpt;
+    this.setFieldValue(value, 'OPTION');
   },
 
   /**
@@ -96,5 +97,28 @@ Blockly.Blocks['helpers_dropdown'] = {
       }
     }
     return options;
+  },
+
+  typeblock: function() {
+    var db = Blockly.mainWorkspace.getComponentDatabase();
+    var tb = [];
+
+    db.forEachOptionList(function(optionList) {
+      for (var i = 0, option; option = optionList.options[i]; i++) {
+        var tag = db.getInternationalizedOptionListTag(optionList.tag);
+        var key = optionList.tag + option.name;
+        var i18nName = db.getInternationalizedOptionName(key, option.name);
+        tb.push({
+          // TODO: This doesn't handle rtl langs, anyway to fix that?
+          translatedName: tag + ": " + i18nName,
+          mutatorAttributes: {
+            key: optionList.tag,
+            value: option.name
+          }
+        });
+      }
+    });
+
+    return tb;
   }
 }

--- a/appinventor/blocklyeditor/src/component_database.js
+++ b/appinventor/blocklyeditor/src/component_database.js
@@ -674,6 +674,16 @@ Blockly.ComponentDatabase.prototype.getOptionList = function(key) {
 }
 
 /**
+ * Iterate over all option list definitions calling the callback function with
+ * the OptionList
+ *
+ * @param {function(!OptionList)} callback
+ */
+Blockly.ComponentDatabase.prototype.forEachOptionList = function(callback) {
+  goog.object.forEach(this.optionLists_, callback);
+}
+
+/**
  * Get the internationalized string for the given component type.
  * @param {!string} name String naming a component type
  * @param {?string=name} opt_default Optional default value (default: name parameter)


### PR DESCRIPTION
### Description

Depends on #7 

Adds the ability to get dropdown blocks via typeblock. Typeblock allows you to click on the workspace, and start typing. You will then be able to select from matching blocks, and it will be added to your workspace.

### Testing

1. Began typing Direction
2. Observed that all of the direction options were available.
3. Selected Direction: North.
4. Observed how the dropdown block was correctly added to the workspace.

### Recommended Method for Review
1. Read the below and ask Beka any questions.
Typeblock works by looking at each block definition for a typeblock function. It then calls that function. The function should return an array of objects of the following form:
```
{
  translatedName: "the thing to type to get the block - translated into the current language",
  mutatorAttribute: {  // Optional
    attributeName1: "attribute value 1",
    attributeName2: "attribute value 2",
    attributeNameEtc: "attribute value etc"
  }
}
```

In this case the mutator attributes are the key to get the helper data, and the value of the dropdown we want to select.

2. Review the changes.
