### PR TITLE
Component processing (Design 3 method)

### DIFF
--- a/appinventor/components/src/com/google/appinventor/components/common/Default.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/Default.java
@@ -1,0 +1,15 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Default { }

--- a/appinventor/components/src/com/google/appinventor/components/common/Direction.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/Direction.java
@@ -1,0 +1,46 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a Direction type used by the Sprite component (and subclasses).
+ */
+public enum Direction implements OptionList {
+  North(1),
+  Northeast(2),
+  @Default
+  East(3),
+  Southeast(4),
+  South(-1),
+  Southwest(-2),
+  West(-3),
+  Northwest(-4);
+
+  private int value;
+
+  Direction(int dir) {
+    this.value = dir;
+  }
+
+  public Integer getValue() {
+    return value;
+  }
+
+  private static final Map<Integer, Direction> lookup = new HashMap<>();
+
+  static {
+    for(Direction dir : Direction.values()) {
+      lookup.put(dir.getValue(), dir);
+    }
+  }
+
+  public static Direction get(int dir) {
+    return lookup.get(dir);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/MapFeature.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/MapFeature.java
@@ -1,0 +1,42 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a MapFeature type used by various components than can be added to a map.
+ */
+public enum MapFeature implements OptionList {
+  Circle("Circle"),
+  LineString("LineString"),
+  Marker("Marker"),
+  Polygon("Polygon"),
+  Rectangle("Rectangle");
+
+  private String value;
+
+  MapFeature(String feat) {
+    this.value = feat;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  private static final Map<String, MapFeature> lookup = new HashMap<>();
+
+  static {
+    for(MapFeature feat : MapFeature.values()) {
+      lookup.put(feat.getValue(), feat);
+    }
+  }
+
+  public static MapFeature get(int feat) {
+    return lookup.get(feat);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/OptionList.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/OptionList.java
@@ -1,0 +1,17 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+/**
+ * A marker interface for defining option list helper blocks via the Java scripting language.
+ * This can be expanded later if we want to get more information aout of option list definitions.
+ */
+public interface OptionList {
+    /**
+     * Returns the underlying primitive value of the option.
+     */
+    public Object getValue();
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/ScreenAnimation.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ScreenAnimation.java
@@ -1,0 +1,44 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a ScreenAnimation type used by the Form component to specify its open and close
+ * animations.
+ */
+public enum ScreenAnimation implements OptionList {
+  Default("default"),
+  Fade("fade"),
+  Zoom("zoom"),
+  SlideHorizontal("slidehorizontal"),
+  SlideVertical("slidevertical"),
+  None("none");
+
+  private String value;
+
+  ScreenAnimation(String anim) {
+    this.value = anim;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  private static final Map<String, ScreenAnimation> lookup = new HashMap<>();
+
+  static {
+    for(ScreenAnimation anim : ScreenAnimation.values()) {
+      lookup.put(anim.getValue(), anim);
+    }
+  }
+
+  public static ScreenAnimation get(String anim) {
+    return lookup.get(anim);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Circle.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Circle.java
@@ -17,6 +17,7 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.MapFeature;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.GeometryUtil;
@@ -123,7 +124,12 @@ public class Circle extends PolygonBase implements MapCircle {
   @SimpleProperty(description = "Returns the type of the feature. For Circles, "
       + "this returns the text \"Circle\".")
   public String Type() {
-    return MapFactory.MapFeatureType.TYPE_CIRCLE;
+    return MapFeature.Circle.getValue();
+  }
+
+  @SimpleProperty
+  public MapFeature TypeOptions() {
+    return MapFeature.Circle;
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -55,6 +55,7 @@ import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.ScreenAnimation;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.collect.Lists;
 import com.google.appinventor.components.runtime.collect.Maps;
@@ -188,9 +189,9 @@ public class Form extends AppInventorCompatActivity
   private int horizontalAlignment;
   private int verticalAlignment;
 
-  // String representing the transition animation type
-  private String openAnimType;
-  private String closeAnimType;
+  // Represents the transition animation type.
+  private ScreenAnimation openAnimType;
+  private ScreenAnimation closeAnimType;
 
   // Syle information
   private int primaryColor = DEFAULT_PRIMARY_COLOR;
@@ -1611,6 +1612,14 @@ public class Form extends AppInventorCompatActivity
     description = "The animation for switching to another screen. Valid" +
     " options are default, fade, zoom, slidehorizontal, slidevertical, and none"    )
   public String OpenScreenAnimation() {
+    if (openAnimType != null) {
+      return openAnimType.getValue();
+    }
+    return null;
+  }
+
+  @SimpleProperty
+  public ScreenAnimation OpenScreenAnimationOptions() {
     return openAnimType;
   }
 
@@ -1624,13 +1633,18 @@ public class Form extends AppInventorCompatActivity
     defaultValue = "default")
   @SimpleProperty
   public void OpenScreenAnimation(String animType) {
-    if ((animType != "default") &&
-      (animType != "fade") && (animType != "zoom") && (animType != "slidehorizontal") &&
-      (animType != "slidevertical") && (animType != "none")) {
+    // Make sure that "animType" is a valid ScreenAnimation.
+    ScreenAnimation anim = ScreenAnimation.get(animType);
+    if (anim == null) {
       this.dispatchErrorOccurredEvent(this, "Screen",
         ErrorMessages.ERROR_SCREEN_INVALID_ANIMATION, animType);
       return;
     }
+    OpenScreenAnimationOptions(anim);
+  }
+
+  @SimpleProperty
+  public void OpenScreenAnimationOptions(ScreenAnimation animType) {
     openAnimType = animType;
   }
 
@@ -1645,6 +1659,13 @@ public class Form extends AppInventorCompatActivity
     " to the previous screen. Valid options are default, fade, zoom, slidehorizontal, " +
     "slidevertical, and none")
   public String CloseScreenAnimation() {
+    if (closeAnimType != null) {
+      return closeAnimType.getValue();
+    }
+    return null;
+  }
+
+  public ScreenAnimation CloseScreenAnimationOptions() {
     return closeAnimType;
   }
 
@@ -1658,13 +1679,17 @@ public class Form extends AppInventorCompatActivity
     defaultValue = "default")
   @SimpleProperty
   public void CloseScreenAnimation(String animType) {
-    if ((animType != "default") &&
-      (animType != "fade") && (animType != "zoom") && (animType != "slidehorizontal") &&
-      (animType != "slidevertical") && (animType != "none")) {
+    // Make sure "animType" is a valid ScreenAnimation.
+    ScreenAnimation anim = ScreenAnimation.get(animType);
+    if (anim == null) {
       this.dispatchErrorOccurredEvent(this, "Screen",
         ErrorMessages.ERROR_SCREEN_INVALID_ANIMATION, animType);
       return;
     }
+    CloseScreenAnimationOptions(anim);
+  }
+
+  public void CloseScreenAnimationOptions(ScreenAnimation animType) {
     closeAnimType = animType;
   }
 
@@ -1673,7 +1698,7 @@ public class Form extends AppInventorCompatActivity
    * animation
    */
   public String getOpenAnimType() {
-    return openAnimType;
+    return openAnimType.getValue();
   }
 
   /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/LineString.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/LineString.java
@@ -22,6 +22,7 @@ import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.MapFeature;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.MapFactory.MapCircle;
@@ -111,7 +112,12 @@ public class LineString extends MapFeatureBase implements MapLineString {
           + "the text \"LineString\".")
   @Override
   public String Type() {
-    return MapFactory.MapFeatureType.TYPE_LINESTRING;
+    return MapFeature.LineString.getValue();
+  }
+
+  @SimpleProperty
+  public MapFeature TypeOptions() {
+    return MapFeature.LineString;
   }
 
   @SimpleProperty(category = PropertyCategory.APPEARANCE,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
@@ -20,11 +20,11 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesLibraries;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.MapFeature;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.GeometryUtil;
 import com.google.appinventor.components.runtime.util.MapFactory.MapCircle;
-import com.google.appinventor.components.runtime.util.MapFactory.MapFeature;
 import com.google.appinventor.components.runtime.util.MapFactory.MapFeatureVisitor;
 import com.google.appinventor.components.runtime.util.MapFactory.MapLineString;
 import com.google.appinventor.components.runtime.util.MapFactory.MapMarker;
@@ -195,7 +195,12 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   @SimpleProperty
   @Override
   public String Type() {
-    return MapFactory.MapFeatureType.TYPE_MARKER;
+    return MapFeature.Marker.getValue();
+  }
+
+  @SimpleProperty
+  public MapFeature TypeOptions() {
+    return MapFeature.Marker;
   }
 
   /**
@@ -509,7 +514,7 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
       "in degrees from due north. If the centroids parameter is true, the bearing will be to the " +
       "center of the map feature. Otherwise, the bearing will be computed to the point in the " +
       "feature nearest the Marker.")
-  public double BearingToFeature(MapFeature mapFeature, final boolean centroids) {
+  public double BearingToFeature(MapFactory.MapFeature mapFeature, final boolean centroids) {
     return mapFeature == null ? -1 : mapFeature.accept(bearingComputation, this, centroids);
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Polygon.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Polygon.java
@@ -15,6 +15,7 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.MapFeature;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.errors.DispatchableError;
@@ -120,7 +121,12 @@ public class Polygon extends PolygonBase implements MapPolygon {
       description = "Returns the type of the feature. For polygons, this returns the text "
           + "\"Polygon\".")
   public String Type() {
-    return MapFactory.MapFeatureType.TYPE_POLYGON;
+    return MapFeature.Polygon.getValue();
+  }
+
+  @SimpleProperty
+  public MapFeature TypeOptions() {
+    return MapFeature.Polygon;
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Rectangle.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Rectangle.java
@@ -12,6 +12,7 @@ import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.MapFeature;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
@@ -100,8 +101,14 @@ public class Rectangle extends PolygonBase implements MapRectangle {
       description = "Returns the type of the feature. For rectangles, this returns the text "
           + "\"Rectangle\".")
   public String Type() {
-    return MapFactory.MapFeatureType.TYPE_RECTANGLE;
+    return MapFeature.Rectangle.getValue();
   }
+
+  @SimpleProperty
+  public MapFeature TypeOptions() {
+    return MapFeature.Rectangle;
+  }
+
 
   /**
    * Specifies the east-most edge of the `Rectangle`, in decimal degrees east of the prime meridian.

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/AnimationUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/AnimationUtil.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationSet;
 import android.view.animation.TranslateAnimation;
+import com.google.appinventor.components.common.ScreenAnimation;
 
 /**
  * This class supplies some support for pre-defined component animation.
@@ -79,6 +80,11 @@ public final class AnimationUtil {
    * @param animType - the animation type
    */
   public static void ApplyOpenScreenAnimation(Activity activity, String animType) {
+    ScreenAnimation anim = ScreenAnimation.get(animType);
+    ApplyOpenScreenAnimation(activity, anim);
+  }
+
+  public static void ApplyOpenScreenAnimation(Activity activity, ScreenAnimation animType) {
     if (animType == null) {
       return;
     }
@@ -89,25 +95,29 @@ public final class AnimationUtil {
     int enter = 0;
     int exit = 0;
 
-    if (animType.equalsIgnoreCase("fade")) {
-      enter = activity.getResources().getIdentifier("fadein", "anim", activity.getPackageName());
-      exit = activity.getResources().getIdentifier("hold", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("zoom")) {
-      exit = activity.getResources().getIdentifier("zoom_exit", "anim", activity.getPackageName());
-      enter = activity.getResources().getIdentifier("zoom_enter", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("slidehorizontal")) {
-      exit = activity.getResources().getIdentifier("slide_exit", "anim", activity.getPackageName());
-      enter = activity.getResources().getIdentifier("slide_enter", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("slidevertical")) {
-      exit = activity.getResources().getIdentifier("slide_v_exit", "anim", activity.getPackageName());
-      enter = activity.getResources().getIdentifier("slide_v_enter", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("none")) {
-      // enter and exit are already set to 0, so
-      // no animations will be played.
-    } else {
-      // Return here so overridePendingTransitions isn't run, and android
-      // does it's default thing.
-      return;
+    switch (animType) {
+      case Fade:
+        enter = activity.getResources().getIdentifier("fadein", "anim", activity.getPackageName());
+        exit = activity.getResources().getIdentifier("hold", "anim", activity.getPackageName());
+        break;
+      case Zoom:
+        exit = activity.getResources().getIdentifier("zoom_exit", "anim", activity.getPackageName());
+        enter = activity.getResources().getIdentifier("zoom_enter", "anim", activity.getPackageName());
+        break;
+      case SlideHorizontal:
+        exit = activity.getResources().getIdentifier("slide_exit", "anim", activity.getPackageName());
+        enter = activity.getResources().getIdentifier("slide_enter", "anim", activity.getPackageName());
+        break;
+      case SlideVertical:
+        exit = activity.getResources().getIdentifier("slide_v_exit", "anim", activity.getPackageName());
+        enter = activity.getResources().getIdentifier("slide_v_enter", "anim", activity.getPackageName());
+        break;
+      case None:
+        // enter and exit are already set to 0, so no animations will be played.
+        break;
+      default:
+        // Return here so overridePendingTransitions isn't run, and android does it's default thing.
+        return;
     }
     EclairUtil.overridePendingTransitions(activity, enter, exit);
   }
@@ -119,6 +129,11 @@ public final class AnimationUtil {
    * @param animType - the animation type
    */
   public static void ApplyCloseScreenAnimation(Activity activity, String animType) {
+    ScreenAnimation anim = ScreenAnimation.get(animType);
+    ApplyCloseScreenAnimation(activity, anim);
+  }
+
+  public static void ApplyCloseScreenAnimation(Activity activity, ScreenAnimation animType) {
     if (animType == null) {
       return;
     }
@@ -128,27 +143,31 @@ public final class AnimationUtil {
     }
     int enter = 0;
     int exit = 0;
-    if (animType.equalsIgnoreCase("fade")) {
-      exit = activity.getResources().getIdentifier("fadeout", "anim", activity.getPackageName());
-      enter = activity.getResources().getIdentifier("hold", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("zoom")) {
-      exit = activity.getResources().getIdentifier("zoom_exit_reverse", "anim", activity.getPackageName());
-      enter = activity.getResources().getIdentifier("zoom_enter_reverse", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("slidehorizontal")) {
-      exit = activity.getResources().getIdentifier("slide_exit_reverse", "anim", activity.getPackageName());
-      enter = activity.getResources().getIdentifier("slide_enter_reverse", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("slidevertical")) {
-      exit = activity.getResources().getIdentifier("slide_v_exit_reverse", "anim", activity.getPackageName());
-      enter = activity.getResources().getIdentifier("slide_v_enter_reverse", "anim", activity.getPackageName());
-    } else if (animType.equalsIgnoreCase("none")) {
-      // enter and exit are already set to 0, so
-      // no animations will be played.
-    } else {
-      // Return here so overridePendingTransitions isn't run, and android
-      // does it's default thing.
-      return;
+    switch (animType) {
+      case Fade:
+        exit = activity.getResources().getIdentifier("fadeout", "anim", activity.getPackageName());
+        enter = activity.getResources().getIdentifier("hold", "anim", activity.getPackageName());
+        break;
+      case Zoom:
+        exit = activity.getResources().getIdentifier("zoom_exit_reverse", "anim", activity.getPackageName());
+        enter = activity.getResources().getIdentifier("zoom_enter_reverse", "anim", activity.getPackageName());
+        break;
+      case SlideHorizontal:
+        exit = activity.getResources().getIdentifier("slide_exit_reverse", "anim", activity.getPackageName());
+        enter = activity.getResources().getIdentifier("slide_enter_reverse", "anim", activity.getPackageName());
+        break;
+      case SlideVertical:
+        exit = activity.getResources().getIdentifier("slide_v_exit_reverse", "anim", activity.getPackageName());
+        enter = activity.getResources().getIdentifier("slide_v_enter_reverse", "anim", activity.getPackageName());
+        break;
+      case None:
+        // enter and exit are already set to 0, so no animations will be played.
+        break;
+      default:
+        // Return here so overridePendingTransitions isn't run, and android does it's default thing.
+        return;
     }
+
     EclairUtil.overridePendingTransitions(activity, enter, exit);
   }
-
 }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -283,6 +283,10 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append(formatDescription(prop.getDescription()));
     sb.append(", \"type\": \"");
     sb.append(prop.getYailType());
+    if (prop.getConcreteYailType() != null) {
+      sb.append("\", \"concreteType\": \"");
+      sb.append(prop.getConcreteYailType());
+    }
     sb.append("\", \"rw\": \"");
     sb.append(prop.isUserVisible() ? prop.getRwString() : "invisible");
     // [lyn, 2015/12/20] Added deprecated field to JSON.

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -283,10 +283,6 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append(formatDescription(prop.getDescription()));
     sb.append(", \"type\": \"");
     sb.append(prop.getYailType());
-    if (prop.getConcreteYailType() != null) {
-      sb.append("\", \"concreteType\": \"");
-      sb.append(prop.getConcreteYailType());
-    }
     sb.append("\", \"rw\": \"");
     sb.append(prop.isUserVisible() ? prop.getRwString() : "invisible");
     // [lyn, 2015/12/20] Added deprecated field to JSON.
@@ -295,7 +291,6 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("\", \"deprecated\": \"");
     sb.append(prop.isDeprecated());
     sb.append("\"");
-    outputHelper(prop.getHelperKey(), sb);
     if (alwaysSend) {
       sb.append(", \"alwaysSend\": true, \"defaultValue\": \"");
       sb.append(defaultValue.replaceAll("\"", "\\\""));
@@ -340,7 +335,6 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       sb.append(method.getYailReturnType());
       sb.append("\"");
     }
-    outputHelper(method.getReturnHelperKey(), sb);
     sb.append("}");
   }
 
@@ -356,64 +350,10 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       sb.append(p.name);
       sb.append("\", \"type\": \"");
       sb.append(p.getYailType());
-      if (p.getConcreteYailType() != null) {
-        sb.append("\", \"concreteType\": \"");
-        sb.append(p.getConcreteYailType());
-      }
-      sb.append("\"");
-      outputHelper(p.getHelperKey(), sb);
-      sb.append("}");
+      sb.append("\"}");
       separator = ",";
     }
     sb.append("]");
-  }
-
-  private void outputHelper(HelperKey helper, StringBuilder sb) {
-    if (helper == null) {
-      return;
-    }
-    sb.append(", \"helper\": {\n");
-    sb.append("    \"type\": \"");
-    sb.append(helper.getType());
-    sb.append("\",\n");
-    sb.append("    \"data\": {\n");
-    switch (helper.getType()) {
-      case OPTION_LIST:
-        outputOptionList(helper.getKey(), sb);
-    }
-    sb.append("    }\n}");
-  }
-
-  private void outputOptionList(String key, StringBuilder sb) {
-    OptionList optList = optionLists.get(key);
-    sb.append("      \"className\": \"");
-    sb.append(optList.getClassName());
-    sb.append("\",\n");
-    sb.append("      \"key\": \"");
-    sb.append(key);
-    sb.append("\",\n");
-    sb.append("      \"tag\": \"");
-    sb.append(optList.getTagName());
-    sb.append("\",\n");
-    sb.append("      \"defaultOpt\": \"");
-    sb.append(optList.getDefault());
-    sb.append("\",\n");
-    sb.append("      \"options\": [\n");
-    String separator = "";
-    for (Option opt : optList.asCollection()) {
-      sb.append(separator);
-      sb.append("        { \"name\": \"");
-      sb.append(opt.name);
-      sb.append("\", \"value\": \"");
-      sb.append(opt.getValue());
-      sb.append("\", \"description\": ");
-      sb.append(formatDescription(opt.getDescription()));
-      sb.append(", \"deprecated\": \"");
-      sb.append(opt.isDeprecated());
-      sb.append("\" }");
-      separator = ",\n";
-    }
-    sb.append("\n      ]\n");
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -355,6 +355,10 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       sb.append(p.name);
       sb.append("\", \"type\": \"");
       sb.append(p.getYailType());
+      if (p.getConcreteYailType() != null) {
+        sb.append("\", \"concreteType\": \"");
+        sb.append(p.getConcreteYailType());
+      }
       sb.append("\"}");
       separator = ",";
     }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -282,7 +282,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("\", \"description\": ");
     sb.append(formatDescription(prop.getDescription()));
     sb.append(", \"type\": \"");
-    sb.append(javaTypeToYailType(prop.getType()));
+    sb.append(prop.getYailType());
     sb.append("\", \"rw\": \"");
     sb.append(prop.isUserVisible() ? prop.getRwString() : "invisible");
     // [lyn, 2015/12/20] Added deprecated field to JSON.
@@ -332,7 +332,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     outputParameters(method.parameters, sb);
     if (method.getReturnType() != null) {
       sb.append(", \"returnType\": \"");
-      sb.append(javaTypeToYailType(method.getReturnType()));
+      sb.append(method.getYailReturnType());
       sb.append("\"}");
     } else {
       sb.append("}");
@@ -350,7 +350,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
       sb.append("{ \"name\": \"");
       sb.append(p.name);
       sb.append("\", \"type\": \"");
-      sb.append(javaTypeToYailType(p.type));
+      sb.append(p.getYailType());
       sb.append("\"}");
       separator = ",";
     }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentDescriptorGenerator.java
@@ -295,6 +295,7 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     sb.append("\", \"deprecated\": \"");
     sb.append(prop.isDeprecated());
     sb.append("\"");
+    outputHelper(prop.getHelperKey(), sb);
     if (alwaysSend) {
       sb.append(", \"alwaysSend\": true, \"defaultValue\": \"");
       sb.append(defaultValue.replaceAll("\"", "\\\""));
@@ -337,10 +338,10 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
     if (method.getReturnType() != null) {
       sb.append(", \"returnType\": \"");
       sb.append(method.getYailReturnType());
-      sb.append("\"}");
-    } else {
-      sb.append("}");
+      sb.append("\"");
     }
+    outputHelper(method.getReturnHelperKey(), sb);
+    sb.append("}");
   }
 
   /*
@@ -359,10 +360,60 @@ public final class ComponentDescriptorGenerator extends ComponentProcessor {
         sb.append("\", \"concreteType\": \"");
         sb.append(p.getConcreteYailType());
       }
-      sb.append("\"}");
+      sb.append("\"");
+      outputHelper(p.getHelperKey(), sb);
+      sb.append("}");
       separator = ",";
     }
     sb.append("]");
+  }
+
+  private void outputHelper(HelperKey helper, StringBuilder sb) {
+    if (helper == null) {
+      return;
+    }
+    sb.append(", \"helper\": {\n");
+    sb.append("    \"type\": \"");
+    sb.append(helper.getType());
+    sb.append("\",\n");
+    sb.append("    \"data\": {\n");
+    switch (helper.getType()) {
+      case OPTION_LIST:
+        outputOptionList(helper.getKey(), sb);
+    }
+    sb.append("    }\n}");
+  }
+
+  private void outputOptionList(String key, StringBuilder sb) {
+    OptionList optList = optionLists.get(key);
+    sb.append("      \"className\": \"");
+    sb.append(optList.getClassName());
+    sb.append("\",\n");
+    sb.append("      \"key\": \"");
+    sb.append(key);
+    sb.append("\",\n");
+    sb.append("      \"tag\": \"");
+    sb.append(optList.getTagName());
+    sb.append("\",\n");
+    sb.append("      \"defaultOpt\": \"");
+    sb.append(optList.getDefault());
+    sb.append("\",\n");
+    sb.append("      \"options\": [\n");
+    String separator = "";
+    for (Option opt : optList.asCollection()) {
+      sb.append(separator);
+      sb.append("        { \"name\": \"");
+      sb.append(opt.name);
+      sb.append("\", \"value\": \"");
+      sb.append(opt.getValue());
+      sb.append("\", \"description\": ");
+      sb.append(formatDescription(opt.getDescription()));
+      sb.append(", \"deprecated\": \"");
+      sb.append(opt.isDeprecated());
+      sb.append("\" }");
+      separator = ",\n";
+    }
+    sb.append("\n      ]\n");
   }
 
   @Override

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -273,6 +273,8 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     @Override
     public Parameter clone() {
       Parameter param = new Parameter (name, type, color);
+      param.concreteType = concreteType;
+      param.helper = helper;
       return param;
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -562,7 +562,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     public void mergeWithOptionsVersion(Object methodObj) {
       Method optionsMethod = (Method) methodObj;
       if ((returnType == null && optionsMethod.returnType != null) ||
-          !returnType.equals(optionsMethod.returnType)) {
+          (returnType != null && !returnType.equals(optionsMethod.returnType))) {
         String correctType = returnType == null ? "void" : getReturnType();
         throw new RuntimeException("Options @SimpleFunction " + optionsMethod.name + " must have " +
             "the same return type as the original " + name + " function (" + correctType + ")");

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1943,17 +1943,20 @@ public abstract class ComponentProcessor extends AbstractProcessor {
     }
 
     // Merge all of the abstract and concrete properties.
+    Set<String> keysToRemove = new HashSet<>();
     for (Map.Entry<String, Property> entry : componentInfo.properties.entrySet()) {
       String key = entry.getKey();
       String suffix = "Options";
       if (key.endsWith(suffix)) {
         String suffixlessKey = key.substring(0, key.length() - suffix.length());
         if (componentInfo.properties.containsKey(suffixlessKey)) {
-          Property optionsProperty = componentInfo.properties.get(suffixlessKey);
-          entry.getValue().mergeWithOptionsProperty(optionsProperty);
+          Property concreteProperty = componentInfo.properties.get(suffixlessKey);
+          concreteProperty.mergeWithOptionsProperty(entry.getValue());
+          keysToRemove.add(key);
         }
       }
     }
+    componentInfo.properties.keySet().removeAll(keysToRemove);
   }
 
   // Note: The top halves of the bodies of processEvent() and processMethods()

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentTranslationGenerator.java
@@ -7,6 +7,7 @@ package com.google.appinventor.components.scripts;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -79,13 +80,20 @@ public final class ComponentTranslationGenerator extends ComponentProcessor {
         outMethods.add(propertyName);
       }
     }
-    // This special case adds the notAlreadyHandled parameter, which is the second parameter for the generic event
-    // handlers. Since it's not explicitly declared in any event handler, we add it here for internationalization.
-    parameters.put("notAlreadyHandled", new Parameter("notAlreadyHandled", "boolean"));
+
     sb.append("\n\n/* Parameters */\n\n");
+    // TODO: Instead of compiling the names here, can we just create a list instead of a map?
+    ArrayList<String> names = new ArrayList();
     for (Parameter parameter : parameters.values()) {
-      sb.append("    map.put(\"PARAM-" + parameter.name + "\", MESSAGES." +
-          Character.toLowerCase(parameter.name.charAt(0)) + parameter.name.substring(1) +
+      names.add(parameter.name);
+    }
+    // This special case adds the notAlreadyHandled parameter, which is the second parameter for the
+    // generic event handlers. Since it's not explicitly declared in an event handler, we have to
+    // add it here for internationalization.
+    names.add("notAlreadyHandled");
+    for (String name : names) {
+      sb.append("    map.put(\"PARAM-" + name + "\", MESSAGES." +
+          Character.toLowerCase(name.charAt(0)) + name.substring(1) +
           "Params());\n");
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/DocumentationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/DocumentationGenerator.java
@@ -237,7 +237,7 @@ public class DocumentationGenerator extends ComponentProcessor {
         String returnType = method.getReturnType();
         writer.write(getMethodDefinition(
             method.name, method.toParameterString(),
-            returnType == null ? "" : javaTypeToYailType(returnType),
+            returnType == null ? "" : method.getYailReturnType(),
             method.description));
         definitionWritten = true;
       }

--- a/appinventor/components/src/com/google/appinventor/components/scripts/MarkdownDocumentationGenerator.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/MarkdownDocumentationGenerator.java
@@ -100,7 +100,7 @@ public class MarkdownDocumentationGenerator extends ComponentProcessor {
   }
 
   private String getPropertyClass(ComponentInfo info, Property property) {
-    String cls = property.isColor() ? COLOR_TYPE : javaTypeToYailType(property.getType());
+    String cls = property.isColor() ? COLOR_TYPE : property.getYailType();
     if (!property.isWritable()) {
       cls += " .ro";
     }
@@ -142,7 +142,7 @@ public class MarkdownDocumentationGenerator extends ComponentProcessor {
       }
       String returnType = "";
       if (method.getReturnType() != null) {
-        returnType = method.isColor() ? COLOR_TYPE : javaTypeToYailType(method.getReturnType());
+        returnType = method.isColor() ? COLOR_TYPE : method.getYailReturnType();
         returnType = " returns " + returnType;
       }
       out.write(String.format("%n%n{:id=\"%s.%s\" class=\"method%s\"} <i/> %s(%s)%n: ", name,
@@ -161,7 +161,7 @@ public class MarkdownDocumentationGenerator extends ComponentProcessor {
     for (Parameter param : parameters) {
       sb.append(separator);
       sb.append(String.format("*%s*{:.%s}", param.name,
-          param.color ? COLOR_TYPE : javaTypeToYailType(param.type)));
+          param.color ? COLOR_TYPE : param.getYailType()));
       separator = ",";
     }
     return sb.toString();

--- a/appinventor/docs/markdown/reference/components/animation.md
+++ b/appinventor/docs/markdown/reference/components/animation.md
@@ -97,7 +97,7 @@ A round 'sprite' that can be placed on a [`Canvas`](#Canvas), where it can react
  anywhere in response to the Dragged event unless
  [`MoveTo`](#Ball.MoveTo) is specifically called.
 
-{:id="Ball.EdgeReached"} EdgeReached(*edge*{:.number})
+{:id="Ball.EdgeReached"} EdgeReached(*edge*{:.com.google.appinventor.components.common.DirectionEnum})
 : Event handler called when the `Ball` reaches an `edge`{:.variable.block} of the screen.
  If [`Bounce`](#Ball.Bounce) is then called with that edge, the sprite will appear to bounce off
  of the edge it reached. Edge here is represented as an integer that indicates one of eight
@@ -132,7 +132,7 @@ A round 'sprite' that can be placed on a [`Canvas`](#Canvas), where it can react
 
 {:.methods}
 
-{:id="Ball.Bounce" class="method"} <i/> Bounce(*edge*{:.number})
+{:id="Ball.Bounce" class="method"} <i/> Bounce(*edge*{:.com.google.appinventor.components.common.DirectionEnum})
 : Makes this `Ball` bounce, as if off a wall. For normal bouncing, the `edge` argument should
  be the one returned by [`EdgeReached`](#Ball.EdgeReached).
 
@@ -412,7 +412,7 @@ A 'sprite' that can be placed on a [`Canvas`](#Canvas), where it can react to to
  anywhere in response to the Dragged event unless
  [`MoveTo`](#ImageSprite.MoveTo) is specifically called.
 
-{:id="ImageSprite.EdgeReached"} EdgeReached(*edge*{:.number})
+{:id="ImageSprite.EdgeReached"} EdgeReached(*edge*{:.com.google.appinventor.components.common.DirectionEnum})
 : Event handler called when the `ImageSprite` reaches an `edge`{:.variable.block} of the screen.
  If [`Bounce`](#ImageSprite.Bounce) is then called with that edge, the sprite will appear to bounce off
  of the edge it reached. Edge here is represented as an integer that indicates one of eight
@@ -447,7 +447,7 @@ A 'sprite' that can be placed on a [`Canvas`](#Canvas), where it can react to to
 
 {:.methods}
 
-{:id="ImageSprite.Bounce" class="method"} <i/> Bounce(*edge*{:.number})
+{:id="ImageSprite.Bounce" class="method"} <i/> Bounce(*edge*{:.com.google.appinventor.components.common.DirectionEnum})
 : Makes this `ImageSprite` bounce, as if off a wall. For normal bouncing, the `edge` argument should
  be the one returned by [`EdgeReached`](#ImageSprite.EdgeReached).
 

--- a/appinventor/docs/markdown/reference/components/maps.md
+++ b/appinventor/docs/markdown/reference/components/maps.md
@@ -81,8 +81,8 @@ The `Circle` component visualizes a circle of a given [`Radius`](#Circle.Radius)
 : Sets or gets the title displayed in the info window that appears when the user clicks on the
  map feature.
 
-{:id="Circle.Type" .text .ro .bo} *Type*
-: Returns the type of the feature. For Circles, this returns the text "Circle".
+{:id="Circle.Type" .com.google.appinventor.components.common.MapFeatureEnum .ro .bo} *Type*
+: Property for TypeOptions
 
 {:id="Circle.Visible" .boolean} *Visible*
 : Specifies whether the `Circle` should be visible on the screen.  Value is `true`{:.logic.block}
@@ -304,8 +304,8 @@ A `FeatureCollection` groups one or more map features together. Any events that 
 : Sets or gets the title displayed in the info window that appears when the user clicks on the
  map feature.
 
-{:id="LineString.Type" .text .ro .bo} *Type*
-: Returns the type of the map feature. For LineString, this returns the text "LineString".
+{:id="LineString.Type" .com.google.appinventor.components.common.MapFeatureEnum .ro .bo} *Type*
+: Property for TypeOptions
 
 {:id="LineString.Visible" .boolean} *Visible*
 : Specifies whether the `LineString` should be visible on the screen.  Value is `true`{:.logic.block}
@@ -677,8 +677,8 @@ The `Marker` component indicates points on a [`Map`](#Map), such as buildings or
 : Sets or gets the title displayed in the info window that appears when the user clicks on the
  map feature.
 
-{:id="Marker.Type" .text .ro .bo} *Type*
-: Return the type of the map feature. For Marker, this returns the text "Marker".
+{:id="Marker.Type" .com.google.appinventor.components.common.MapFeatureEnum .ro .bo} *Type*
+: Property for TypeOptions
 
 {:id="Marker.Visible" .boolean} *Visible*
 : Specifies whether the `Marker` should be visible on the screen.  Value is `true`{:.logic.block}
@@ -884,8 +884,8 @@ The Navigation component generates directions between two locations using a serv
 : Sets or gets the title displayed in the info window that appears when the user clicks on the
  map feature.
 
-{:id="Polygon.Type" .text .ro .bo} *Type*
-: Returns the type of the feature. For polygons, this returns the text "Polygon".
+{:id="Polygon.Type" .com.google.appinventor.components.common.MapFeatureEnum .ro .bo} *Type*
+: Property for TypeOptions
 
 {:id="Polygon.Visible" .boolean} *Visible*
 : Specifies whether the `Polygon` should be visible on the screen.  Value is `true`{:.logic.block}
@@ -994,8 +994,8 @@ The Navigation component generates directions between two locations using a serv
 : Sets or gets the title displayed in the info window that appears when the user clicks on the
  map feature.
 
-{:id="Rectangle.Type" .text .ro .bo} *Type*
-: Returns the type of the feature. For rectangles, this returns the text "Rectangle".
+{:id="Rectangle.Type" .com.google.appinventor.components.common.MapFeatureEnum .ro .bo} *Type*
+: Property for TypeOptions
 
 {:id="Rectangle.Visible" .boolean} *Visible*
 : Specifies whether the `Rectangle` should be visible on the screen.  Value is `true`{:.logic.block}

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -978,9 +978,8 @@ Top-level component containing all other components in the program.
  up to 1024x1024 pixels. Larger images may cause compiling or installing the app to fail.
  The build server will generate images of standard dimensions for Android devices.
 
-{:id="Screen.OpenScreenAnimation" .text} *OpenScreenAnimation*
-: The animation for switching to another screen. Valid options are `default`, `fade`, `zoom`,
- `slidehorizontal`, `slidevertical`, and `none`.
+{:id="Screen.OpenScreenAnimation" .com.google.appinventor.components.common.ScreenAnimationEnum} *OpenScreenAnimation*
+: Property for OpenScreenAnimationOptions
 
 {:id="Screen.Platform" .text .ro .bo} *Platform*
 : Gets the name of the underlying platform running the app. Currently, this is the text


### PR DESCRIPTION
### Description

Adds support for processing enums. This PR only handles the turning-java-into-data part of the process, not turning-data-into stuff. For example, this doesn't modify simple-components.json, nor does it do anything with translation.

This supports 2 ways of defining option lists.

1) New style way:
    ````
    @SimpleProperty
    public void FavoriteAnimal(Animal anim) {}
    ````
2) Old style / upgrading way:
    ```
    // Old function.
    @SimpleProperty
    public void FavoriteAnimal(String animal) {}
    
    @SimpleProperty
    public void FavoriteAnimal(Animal anim) {}
    ```

I also created 3 enums Direction, MapFeature, and ScreenAnimation, and added them to the relevant components.
