### PR TITLE
Add HorizontalAlignment and VerticalAlignment

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1040,6 +1040,7 @@ public final class YoungAndroidFormUpgrader {
 
     if (srcCompVersion < 28) {
       // ScreenAnimation dropdown blocks were added.
+      // HorizontalAlignment and VerticalAlignment dropdown blocks were added.
       srcCompVersion = 28;
     }
 

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -275,6 +275,9 @@ public final class YoungAndroidFormUpgrader {
       } else if (componentType.equals("HorizontalArrangement")) {
         srcCompVersion = upgradeHorizontalArrangementProperties(componentProperties, srcCompVersion);
 
+      } else if (componentType.equals("HorizontalScrollArrangement")) {
+        srcCompVersion = upgradeHorizontalScrollArrangementProperties(componentProperties, srcCompVersion);
+
       } else if (componentType.equals("Image")) {
         srcCompVersion = upgradeImageProperties(componentProperties, srcCompVersion);
 
@@ -331,6 +334,9 @@ public final class YoungAndroidFormUpgrader {
 
       } else if (componentType.equals("VerticalArrangement")) {
         srcCompVersion = upgradeVerticalArrangementProperties(componentProperties, srcCompVersion);
+
+      } else if (componentType.equals("VerticalScrollArrangement")) {
+        srcCompVersion = upgradeVerticalScrollArrangementProperties(componentProperties, srcCompVersion);
 
       } else if (componentType.equals("VideoPlayer")) {
         srcCompVersion = upgradeVideoPlayerProperties(componentProperties, srcCompVersion);
@@ -1080,6 +1086,21 @@ public final class YoungAndroidFormUpgrader {
       // - Added background color & image
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+      srcCompVersion = 4;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeHorizontalScrollArrangementProperties(
+    Map<String, JSONValue> componentProperties,
+    int srcCompVersion
+  ) {
+    if (srcCompVersion < 2) {
+      // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+      srcCompVersion = 2;
+    }
     return srcCompVersion;
   }
 
@@ -1444,6 +1465,21 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 3) {
       // - Added background color & image
       srcCompVersion = 3;
+    }
+    if (srcCompVersion < 4) {
+      // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+      srcCompVersion = 4;
+    }
+    return srcCompVersion;
+  }
+
+  private static int upgradeVerticalScrollArrangementProperties(
+    Map<String, JSONValue> componentProperties,
+    int srcCompVersion
+  ) {
+    if (srcCompVersion < 2) {
+      // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+      srcCompVersion = 2;
     }
     return srcCompVersion;
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1723,6 +1723,10 @@ public final class YoungAndroidFormUpgrader {
       // The FillOpacity and StrokeOpacity properties were added
       srcCompVersion = 3;
     }
+    if (srcCompVersion < 4) {
+      // Add AlignHorizontal and AlignVertical dropdown blocks.
+      srcCompVersion = 4;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2477,10 +2477,15 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // For FORM_COMPONENT_VERSION 28:
     // - Adds dropdown blocks for ScreenAnimation.
+    // - Adds dropdown blocks for HorizontalAlignment and VerticalAlignment.
     28: [Blockly.Versioning.makeSetterUseDropdown(
             'Form', 'OpenScreenAnimation', 'ScreenAnimation'),
          Blockly.Versioning.makeSetterUseDropdown(
-            'Form', 'CloseScreenAnimation', 'ScreenAnimation')]
+            'Form', 'CloseScreenAnimation', 'ScreenAnimation'),
+         Blockly.Versioning.makeSetterUseDropdown(
+           'Form', 'AlignHorizontal', 'HorizontalAlignment'),
+         Blockly.Versioning.makeSetterUseDropdown(
+           'Form', 'AlignVertical', 'VerticalAlignment')]
 
   }, // End Screen
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2069,7 +2069,14 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // AI2:
     // - The FillOpacity and StrokeOpacity properties were added
-    3: "noUpgrade"
+    3: "noUpgrade",
+
+    // For MARKER_COMPONENT_VERSION 4:
+    // - Add AlignHorizontal and AlignVertical dropdown blocks.
+    4: [Blockly.Versioning.makeSetterUseDropdown(
+           'Marker', 'AnchorHorizontal', 'HorizontalAlignment'),
+        Blockly.Versioning.makeSetterUseDropdown(
+           'Marker', 'AnchorVertical', 'VerticalAlignment')]
   }, // End Marker upgraders
 
   "Polygon": {

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1690,14 +1690,28 @@ Blockly.Versioning.AllUpgradeMaps =
     2: "noUpgrade",
 
     // - Added background color & image
-    3: "noUpgrade"
+    3: "noUpgrade",
+
+    // For HORIZONTALARRANGEMENT_COMPONENT_VERSION 4:
+    // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+    4: [Blockly.Versioning.makeSetterUseDropdown(
+           'HorizontalArrangement', 'AlignHorizontal', 'HorizontalAlignment'),
+        Blockly.Versioning.makeSetterUseDropdown(
+           'HorizontalArrangement', 'AlignVertical', 'VerticalAlignment')]
 
   }, // End HorizontalArrangement upgraders
 
   "HorizontalScrollArrangement": {
 
     // This is initial version. Placeholder for future upgrades
-    1: "noUpgrade"
+    1: "noUpgrade",
+
+    // For HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION 2:
+    // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+    2: [Blockly.Versioning.makeSetterUseDropdown(
+           'HorizontalScrollArrangement', 'AlignHorizontal', 'HorizontalAlignment'),
+        Blockly.Versioning.makeSetterUseDropdown(
+           'HorizontalScrollArrangement', 'AlignVertical', 'VerticalAlignment')]
 
   }, // End HorizontalScrollArrangement upgraders
 
@@ -2718,15 +2732,27 @@ Blockly.Versioning.AllUpgradeMaps =
     2: "noUpgrade",
 
     // - Added background color & image
-    3: "noUpgrade"
+    3: "noUpgrade",
 
+    // For VERTICALARRANGEMENT_COMPONENT_VERSION 4:
+    // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+    4: [Blockly.Versioning.makeSetterUseDropdown(
+           'VerticalArrangement', 'AlignHorizontal', 'HorizontalAlignment'),
+        Blockly.Versioning.makeSetterUseDropdown(
+           'VerticalArrangement', 'AlignVertical', 'VerticalAlignment')]
   }, // End VerticalArrangement upgraders
 
   "VerticalScrollArrangement": {
 
     //This is initial version. Placeholder for future upgrades
-    1: "noUpgrade"
+    1: "noUpgrade",
 
+    // For VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION 2:
+    // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+    2: [Blockly.Versioning.makeSetterUseDropdown(
+           'VerticalScrollArrangement', 'AlignHorizontal', 'HorizontalAlignment'),
+        Blockly.Versioning.makeSetterUseDropdown(
+           'VerticalScrollArrangement', 'AlignVertical', 'VerticalAlignment')]
   }, // End VerticalScrollArrangement upgraders
 
   "VideoPlayer": {

--- a/appinventor/components/src/com/google/appinventor/components/common/HorizontalAlignment.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/HorizontalAlignment.java
@@ -1,0 +1,41 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a HorizontalAlignment used by a variety of classes including Form, VerticalArrangement,
+ * and Marker.
+ */
+public enum HorizontalAlignment implements OptionList<Integer> {
+  Left(1),
+  Center(3), // Yes this is correct.
+  Right(2);
+
+  private int value;
+
+  HorizontalAlignment(int value) {
+    this.value = value;
+  }
+
+  public Integer toUnderlyingValue() {
+    return value;
+  }
+
+  private static Map<Integer, HorizontalAlignment> lookup = new HashMap<>();
+
+  static {
+    for(HorizontalAlignment alignment : HorizontalAlignment.values()) {
+      lookup.put(alignment.toUnderlyingValue(), alignment);
+    }
+  }
+
+  public static HorizontalAlignment fromUnderlyingValue(Integer alignment) {
+    return lookup.get(alignment);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/VerticalAlignment.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/VerticalAlignment.java
@@ -1,0 +1,42 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a VerticalAlignment used by a variety of classes including Form, HorizontalArrangement,
+ * and Marker.
+ */
+public enum VerticalAlignment implements OptionList<Integer> {
+  Top(1),
+  Center(2),
+  Bottom(3);
+
+  private int value;
+
+  VerticalAlignment(int value) {
+    this.value = value;
+  }
+
+  public Integer toUnderlyingValue() {
+    return value;
+  }
+
+  private static Map<Integer, VerticalAlignment> lookup = new HashMap<>();
+
+  static {
+    for(VerticalAlignment alignment : VerticalAlignment.values()) {
+      lookup.put(alignment.toUnderlyingValue(), alignment);
+    }
+  }
+
+  public static VerticalAlignment fromUnderlyingValue(Integer alignment) {
+    return lookup.get(alignment);
+  }
+}
+

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -907,9 +907,13 @@ public class YaVersion {
   // - The AlignVertical property was added
   // For HORIZONTALARRANGEMENT_COMPONENT_VERSION 3:
   // - Added background color & image
-  public static final int HORIZONTALARRANGEMENT_COMPONENT_VERSION = 3;
+  // For HORIZONTALARRANGEMENT_COMPONENT_VERSION 4:
+  // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+  public static final int HORIZONTALARRANGEMENT_COMPONENT_VERSION = 4;
 
-  public static final int HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION = 1;
+  // For HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION 2:
+  // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+  public static final int HORIZONTALSCROLLARRANGEMENT_COMPONENT_VERSION = 2;
 
   // For IMAGE_COMPONENT_VERSION 2:
   // - The RotationAngle property was added.
@@ -1284,9 +1288,13 @@ public class YaVersion {
   // - The AlignVertical property was added
   // For VERTICALARRANGEMENT_COMPONENT_VERSION 3:
   // - Added background color & image
-  public static final int VERTICALARRANGEMENT_COMPONENT_VERSION = 3;
+  // For VERTICALARRANGEMENT_COMPONENT_VERSION 4:
+  // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+  public static final int VERTICALARRANGEMENT_COMPONENT_VERSION = 4;
 
-  public static final int VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION = 1;
+  // For VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION 2:
+  // - Add HorizontalAlignment and VerticalAlignment dropdown blocks.
+  public static final int VERTICALSCROLLARRANGEMENT_COMPONENT_VERSION = 2;
 
   // For VIDEOPLAYER_COMPONENT_VERSION 2:
   // - The VideoPlayer.VideoPlayerError event was added.

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -884,6 +884,7 @@ public class YaVersion {
   // - Added the Platform and PlatformVersion read-only blocks
   // For FORM_COMPONENT_VERSION 28:
   // - Adds dropdown blocks for ScreenAnimation.
+  // - Adds dropdown blocks for HorizontalAlignment and VerticalAlignment.
   public static final int FORM_COMPONENT_VERSION = 28;
 
   // For FUSIONTABLESCONTROL_COMPONENT_VERSION 2:

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1024,7 +1024,9 @@ public class YaVersion {
   // - The ShowShadow property was removed
   // For MARKER_COMPONENT_VERSION 3:
   // - Added fill and stroke opacity properties
-  public static final int MARKER_COMPONENT_VERSION = 3;
+  // For MARKER_COMPONENT_VERSION 4:
+  // - Add AlignHorizontal and AlignVertical dropdown blocks.
+  public static final int MARKER_COMPONENT_VERSION = 4;
 
   // For NAVIGATION_COMPONENT_VERSION 1:
   // - Initial Navigation implementation

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -55,6 +55,8 @@ import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
+import com.google.appinventor.components.common.HorizontalAlignment;
+import com.google.appinventor.components.common.VerticalAlignment;
 import com.google.appinventor.components.common.PropertyTypeConstants;
 import com.google.appinventor.components.common.ScreenAnimation;
 import com.google.appinventor.components.common.YaVersion;
@@ -186,9 +188,9 @@ public class Form extends AppInventorCompatActivity
   // translates App Inventor alignment codes to Android gravity
   private AlignmentUtil alignmentSetter;
 
-  // the alignment for this component's LinearLayout
-  private int horizontalAlignment;
-  private int verticalAlignment;
+  // The alignment for this component's LinearLayout
+  private HorizontalAlignment horizontalAlignment;
+  private VerticalAlignment verticalAlignment;
 
   // Represents the transition animation type.
   private ScreenAnimation openAnimType;
@@ -1521,12 +1523,6 @@ public class Form extends AppInventorCompatActivity
     }
   }
 
-  // Note(halabelson): This section on centering is duplicated between Form and HVArrangement
-  // I did not see a clean way to abstract it.  Someone should have a look.
-
-  // Note(halabelson): The numeric encodings of the alignment specifications are specified
-  // in ComponentConstants
-
   /**
   * Returns a number that encodes how contents of the screen are aligned horizontally.
   * The choices are: 1 = left aligned, 2 = horizontally centered, 3 = right aligned
@@ -1534,49 +1530,73 @@ public class Form extends AppInventorCompatActivity
   @SimpleProperty(
      category = PropertyCategory.APPEARANCE,
      description = "A number that encodes how contents of the screen are aligned " +
-         " horizontally. The choices are: 1 = left aligned, 2 = horizontally centered, " +
-         " 3 = right aligned.")
- public int AlignHorizontal() {
-   return horizontalAlignment;
- }
+         " horizontally. The choices are: 1 = left aligned, 3 = horizontally centered, " +
+         " 2 = right aligned.")
+  public @Options(HorizontalAlignment.class) int AlignHorizontal() {
+    return horizontalAlignment.toUnderlyingValue();
+  }
+
+ /**
+  * Returns the current alignment of the screen.
+  * @return the current alignment of the screen.
+  */
+  public HorizontalAlignment AlignHorizontalAbstract() {
+    return horizontalAlignment;
+  }
 
  /**
   * A number that encodes how contents of the screen are aligned horizontally. The choices are:
-  * `1` (left aligned), `2` (horizontally centered), `3` (right aligned).
+  * `1` (left aligned), `3` (horizontally centered), `2` (right aligned).
   *
   * @internaldoc
   * Sets the horizontal alignment for contents of the screen
   *
   * @param alignment
   */
- @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_HORIZONTAL_ALIGNMENT,
-     defaultValue = ComponentConstants.HORIZONTAL_ALIGNMENT_DEFAULT + "")
- @SimpleProperty
- public void AlignHorizontal(int alignment) {
-   try {
-     // notice that the throw will prevent the alignment from being changed
-     // if the argument is illegal
-     alignmentSetter.setHorizontalAlignment(alignment);
-     horizontalAlignment = alignment;
-   } catch (IllegalArgumentException e) {
-     this.dispatchErrorOccurredEvent(this, "HorizontalAlignment",
-         ErrorMessages.ERROR_BAD_VALUE_FOR_HORIZONTAL_ALIGNMENT, alignment);
-   }
- }
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_HORIZONTAL_ALIGNMENT,
+      defaultValue = ComponentConstants.HORIZONTAL_ALIGNMENT_DEFAULT + "")
+  @SimpleProperty
+  public void AlignHorizontal(@Options(HorizontalAlignment.class) int alignment) {
+    // Make sure the alignment is a valid HorizontalAlignment.
+    HorizontalAlignment align = HorizontalAlignment.fromUnderlyingValue(alignment);
+    if (align == null) {
+      this.dispatchErrorOccurredEvent(this, "HorizontalAlignment",
+          ErrorMessages.ERROR_BAD_VALUE_FOR_HORIZONTAL_ALIGNMENT, alignment);
+      return;
+    }
+    AlignHorizontalAbstract(align);
+  }
+
+  /**
+   * Sets the horizontal alignment for the contents of the screen.
+   * @param alignment the alignment to set the contents of the screen to.
+   */
+  public void AlignHorizontalAbstract(HorizontalAlignment alignment) {
+    alignmentSetter.setHorizontalAlignment(alignment);
+    horizontalAlignment = alignment;
+  }
 
  /**
   * Returns a number that encodes how contents of the arrangement are aligned vertically.
   * The choices are: 1 = top, 2 = vertically centered, 3 = aligned at the bottom.
   * Vertical alignment has no effect if the screen is scrollable.
   */
- @SimpleProperty(
-     category = PropertyCategory.APPEARANCE,
-     description = "A number that encodes how the contents of the arrangement are aligned " +
-     "vertically. The choices are: 1 = aligned at the top, 2 = vertically centered, " +
-     "3 = aligned at the bottom. Vertical alignment has no effect if the screen is scrollable.")
- public int AlignVertical() {
-   return verticalAlignment;
- }
+  @SimpleProperty(
+      category = PropertyCategory.APPEARANCE,
+      description = "A number that encodes how the contents of the arrangement are aligned " +
+      "vertically. The choices are: 1 = aligned at the top, 2 = vertically centered, " +
+      "3 = aligned at the bottom. Vertical alignment has no effect if the screen is scrollable.")
+  public @Options(VerticalAlignment.class) int AlignVertical() {
+    return verticalAlignment.toUnderlyingValue();
+  }
+
+ /**
+  * Returns the vertical alignment of the screen's contents.
+  * @return the vertical alignment of the screen's contents.
+  */
+  public VerticalAlignment AlignVerticalAbstract() {
+    return verticalAlignment;
+  }
 
  /**
   * A number that encodes how the contents of the arrangement are aligned vertically. The choices
@@ -1588,20 +1608,28 @@ public class Form extends AppInventorCompatActivity
   *
   * @param alignment
   */
- @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_VERTICAL_ALIGNMENT,
-     defaultValue = ComponentConstants.VERTICAL_ALIGNMENT_DEFAULT + "")
- @SimpleProperty
- public void AlignVertical(int alignment) {
-   try {
-     // notice that the throw will prevent the alignment from being changed
-     // if the argument is illegal
-     alignmentSetter.setVerticalAlignment(alignment);
-     verticalAlignment = alignment;
-   } catch (IllegalArgumentException e) {
-     this.dispatchErrorOccurredEvent(this, "VerticalAlignment",
-         ErrorMessages.ERROR_BAD_VALUE_FOR_VERTICAL_ALIGNMENT, alignment);
-   }
- }
+  @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_VERTICAL_ALIGNMENT,
+      defaultValue = ComponentConstants.VERTICAL_ALIGNMENT_DEFAULT + "")
+  @SimpleProperty
+  public void AlignVertical(@Options(VerticalAlignment.class) int alignment) {
+    // Make sure the alignment is a valid VerticalAlignment.
+    VerticalAlignment align = VerticalAlignment.fromUnderlyingValue(alignment);
+    if (align == null) {
+      this.dispatchErrorOccurredEvent(this, "VerticalAlignment",
+          ErrorMessages.ERROR_BAD_VALUE_FOR_VERTICAL_ALIGNMENT, alignment);
+      return;
+    }
+    AlignVerticalAbstract(align);
+  }
+
+  /**
+   * Sets the vertical alignment of the screen's contents.
+   * @param alignment the alignment to set the screen's contents to.
+   */
+  public void AlignVerticalAbstract(VerticalAlignment alignment) {
+    alignmentSetter.setVerticalAlignment(alignment);
+    verticalAlignment = alignment;
+  }
 
  /**
   * Returns the type of open screen animation (default, fade, zoom, slidehorizontal,

--- a/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/HVArrangement.java
@@ -22,12 +22,15 @@ import android.widget.HorizontalScrollView;
 import android.widget.ScrollView;
 
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 
 import com.google.appinventor.components.common.ComponentConstants;
+import com.google.appinventor.components.common.HorizontalAlignment;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.VerticalAlignment;
 
 import com.google.appinventor.components.runtime.util.AlignmentUtil;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
@@ -56,9 +59,9 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
   // translates App Inventor alignment codes to Android gravity
   private AlignmentUtil alignmentSetter;
 
-  // the alignment for this component's LinearLayout
-  private int horizontalAlignment;
-  private int verticalAlignment;
+  // The alignment for this component's LinearLayout.
+  private HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left;
+  private VerticalAlignment verticalAlignment = VerticalAlignment.Top;
   // Backing for background color
   private int backgroundColor;
   // This is the Drawable corresponding to the Image property.
@@ -93,8 +96,6 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
 
     viewLayout.setBaselineAligned(false);
     alignmentSetter = new AlignmentUtil(viewLayout);
-    horizontalAlignment = ComponentConstants.HORIZONTAL_ALIGNMENT_DEFAULT;
-    verticalAlignment = ComponentConstants.VERTICAL_ALIGNMENT_DEFAULT;
     alignmentSetter.setHorizontalAlignment(horizontalAlignment);
     alignmentSetter.setVerticalAlignment(verticalAlignment);
 
@@ -210,11 +211,9 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
     return frameContainer; //: viewLayout.getLayoutManager();
   }
 
-  // The numeric encodings are defined Component Constants
-
   /**
    * Returns a number that encodes how contents of the %type% are aligned horizontally.
-   * The choices are: 1 = left aligned, 2 = right aligned, 3 = horizontally centered
+   * The choices are: 1 = left aligned, 2 = right aligned, 3 = horizontally centered.
    */
   @SimpleProperty(
       category = PropertyCategory.APPEARANCE,
@@ -222,7 +221,14 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
           " horizontally. The choices are: 1 = left aligned, 2 = right aligned, " +
           " 3 = horizontally centered.  Alignment has no effect if the arrangement's width is " +
           "automatic.")
-  public int AlignHorizontal() {
+  public @Options(HorizontalAlignment.class) int AlignHorizontal() {
+    return horizontalAlignment.toUnderlyingValue();
+  }
+
+  /**
+   * Returns the current horizontal alignment of this arrangement.
+   */
+  public HorizontalAlignment AlignHorizontalAbstract() {
     return horizontalAlignment;
   }
 
@@ -236,16 +242,24 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_HORIZONTAL_ALIGNMENT,
       defaultValue = ComponentConstants.HORIZONTAL_ALIGNMENT_DEFAULT + "")
   @SimpleProperty
-  public void AlignHorizontal(int alignment) {
-    try {
-      // notice that the throw will prevent the alignment from being changed
-      // if the argument is illegal
-      alignmentSetter.setHorizontalAlignment(alignment);
-      horizontalAlignment = alignment;
-    } catch (IllegalArgumentException e) {
+  public void AlignHorizontal(@Options(HorizontalAlignment.class) int alignment) {
+    // Make sure alignment is a valid HorizontalAlignment.
+    HorizontalAlignment align = HorizontalAlignment.fromUnderlyingValue(alignment);
+    if (align == null) {
       container.$form().dispatchErrorOccurredEvent(this, "HorizontalAlignment",
           ErrorMessages.ERROR_BAD_VALUE_FOR_HORIZONTAL_ALIGNMENT, alignment);
+      return;
     }
+    AlignHorizontalAbstract(align);
+  }
+
+  /**
+   * Sets the arrangements horizontal alignment to the given value.
+   * @param alignment the alignment to set the arrangement to.
+   */
+  public void AlignHorizontalAbstract(HorizontalAlignment alignment) {
+    alignmentSetter.setHorizontalAlignment(alignment);
+    horizontalAlignment = alignment;
   }
 
   /**
@@ -259,13 +273,20 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
           " vertically. The choices are: 1 = aligned at the top, 2 = vertically centered, " +
           "3 = aligned at the bottom.  Alignment has no effect if the arrangement's height " +
           "is automatic.")
-  public int AlignVertical() {
+  public @Options(VerticalAlignment.class) int AlignVertical() {
+    return verticalAlignment.toUnderlyingValue();
+  }
+
+  /**
+   * Returns the current vertical alignment of this arrangement.
+   */
+  public VerticalAlignment AlignVerticalAbstract() {
     return verticalAlignment;
   }
 
   /**
    * A number that encodes how the contents of the `%type%` are aligned vertically. The choices
-   * are: `1` = aligned at the top, `2` = aligned at the bottom, `3` = vertically centered.
+   * are: `1` = aligned at the top, `2` = vertically centered, `3` = aligned at the bottom.
    * Alignment has no effect if the `%type%`'s {@link #Height()} is `Automatic`.
    *
    * @param alignment
@@ -273,16 +294,24 @@ public class HVArrangement extends AndroidViewComponent implements Component, Co
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_VERTICAL_ALIGNMENT,
       defaultValue = ComponentConstants.VERTICAL_ALIGNMENT_DEFAULT + "")
   @SimpleProperty
-  public void AlignVertical(int alignment) {
-    try {
-      // notice that the throw will prevent the alignment from being changed
-      // if the argument is illegal
-      alignmentSetter.setVerticalAlignment(alignment);
-      verticalAlignment = alignment;
-    } catch (IllegalArgumentException e) {
+  public void AlignVertical(@Options(VerticalAlignment.class) int alignment) {
+    // Make sure alignment is a valid VerticalAlignment.
+    VerticalAlignment align = VerticalAlignment.fromUnderlyingValue(alignment);
+    if (align == null) {
       container.$form().dispatchErrorOccurredEvent(this, "VerticalAlignment",
           ErrorMessages.ERROR_BAD_VALUE_FOR_VERTICAL_ALIGNMENT, alignment);
+      return;
     }
+    AlignVerticalAbstract(align);
+  }
+
+  /**
+   * Sets the arrangements vertical alignment to the given value.
+   * @param alignment the alignment to set the arrangement to.
+   */
+  public void AlignVerticalAbstract(VerticalAlignment alignment) {
+    alignmentSetter.setVerticalAlignment(alignment);
+    verticalAlignment = alignment;
   }
 
     /**

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Marker.java
@@ -21,8 +21,10 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesLibraries;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.HorizontalAlignment;
 import com.google.appinventor.components.common.MapFeature;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.VerticalAlignment;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.GeometryUtil;
 import com.google.appinventor.components.runtime.util.MapFactory.MapCircle;
@@ -58,16 +60,14 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   private String imagePath = "";
 
   /**
-   * Horizontal alignment of the marker drawable relative to its longitude. The default value is 3,
-   * which places the anchor at the horizontal center of the drawable.
+   * Horizontal alignment of the marker drawable relative to its longitude. Defaults to center.
    */
-  private int anchorHAlign = 3;
+  private HorizontalAlignment anchorHAlign = HorizontalAlignment.Center;
 
   /**
-   * Vertical alignment of the marker drawable relative to its latitude. The default value is 3,
-   * which places the anchor at the bottom of the drawable.
+   * Vertical alignment of the marker relative to its latitude. Defaults to bottom.
    */
-  private int anchorVAlign = 3;
+  private VerticalAlignment anchorVAlign = VerticalAlignment.Bottom;
 
   /**
    * Location of the marker's anchor.
@@ -305,15 +305,26 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_HORIZONTAL_ALIGNMENT,
       defaultValue = "3")
   @SimpleProperty
-  public void AnchorHorizontal(int horizontal) {
-    if (horizontal == anchorHAlign) {
-      return;
-    } else if (horizontal > 3 || horizontal < 1) {
-      container.$form().dispatchErrorOccurredEvent(this, "AnchorHorizontal", ErrorMessages.ERROR_INVALID_ANCHOR_HORIZONTAL, horizontal);
+  public void AnchorHorizontal(@Options(HorizontalAlignment.class) int horizontal) {
+    // Make sure the horizontal alignment is a valid HorizontalAlignment.
+    HorizontalAlignment alignment = HorizontalAlignment.fromUnderlyingValue(horizontal);
+    if (alignment == null) {
+      container.$form().dispatchErrorOccurredEvent(this, "AnchorHorizontal",
+          ErrorMessages.ERROR_INVALID_ANCHOR_HORIZONTAL, horizontal);
       return;
     }
-    anchorHAlign = horizontal;
-    map.getController().updateFeaturePosition(this);
+    AnchorHorizontalAbstract(alignment);
+  }
+
+  /**
+   * Sets the horizontal anchor point of this marker relative to its longitude.
+   * @param alignment the alignment to set the anchor point to.
+   */
+  public void AnchorHorizontalAbstract(HorizontalAlignment alignment) {
+    if (alignment != anchorHAlign) {
+      anchorHAlign = alignment;
+      map.getController().updateFeaturePosition(this);
+    }
   }
 
   /**
@@ -322,8 +333,17 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    */
   @Override
   @SimpleProperty(description = "The horizontal alignment property controls where the Marker's " +
-      "anchor is located relative to its width.")
-  public int AnchorHorizontal() {
+      "anchor is located relative to its width. The choices are: 1 = left aligned, 3 = horizontally" +
+      " centered, 2 = right aligned.")
+  public @Options(HorizontalAlignment.class) int AnchorHorizontal() {
+    return anchorHAlign.toUnderlyingValue();
+  }
+
+  /**
+   * Returns the current horizontal alignment of this marker relative to its longitude.
+   * @return the current horizontal alignment of this marker relative to its longitude.
+   */
+  public HorizontalAlignment AnchorHorizontalAbstract() {
     return anchorHAlign;
   }
 
@@ -331,15 +351,25 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
   @DesignerProperty(editorType = PropertyTypeConstants.PROPERTY_TYPE_VERTICAL_ALIGNMENT,
       defaultValue = "3")
   @SimpleProperty
-  public void AnchorVertical(int vertical) {
-    if (vertical == anchorVAlign) {
-      return;
-    } else if (vertical > 3 || vertical < 1) {
+  public void AnchorVertical(@Options(VerticalAlignment.class) int vertical) {
+    // Make sure the vertical alignment is a valid VerticalAlignment.
+    VerticalAlignment alignment = VerticalAlignment.fromUnderlyingValue(vertical);
+    if (alignment == null) {
       container.$form().dispatchErrorOccurredEvent(this, "AnchorVertical", ErrorMessages.ERROR_INVALID_ANCHOR_VERTICAL, vertical);
       return;
     }
-    anchorVAlign = vertical;
-    map.getController().updateFeaturePosition(this);
+    AnchorVerticalAbstract(alignment);
+  }
+  
+  /**
+   * Sets the vertical anchor point of this marker relative to its latitude.
+   * @param alignment the alignment to set the anchor point to.
+   */
+  public void AnchorVerticalAbstract(VerticalAlignment alignment) {
+    if (alignment != null) {
+      anchorVAlign = alignment;
+      map.getController().updateFeaturePosition(this);
+    }
   }
 
   /**
@@ -348,8 +378,17 @@ public class Marker extends MapFeatureBaseWithFill implements MapMarker {
    */
   @Override
   @SimpleProperty(description = "The vertical alignment property controls where the Marker's " +
-      "anchor is located relative to its height.")
-  public int AnchorVertical() {
+      "anchor is located relative to its height. The choices are: 1 = aligned at the top, 2 = vertically " +
+      "centered, 3 = aligned at the bottom.")
+  public @Options(VerticalAlignment.class) int AnchorVertical() {
+    return anchorVAlign.toUnderlyingValue();
+  }
+
+  /**
+   * Returns the current vertical alignment of this marker relative to its latitude.
+   * @return the current vertical alignment of this marker relative to its latitude.
+   */
+  public VerticalAlignment AnchorVerticalAbstract() {
     return anchorVAlign;
   }
 

--- a/appinventor/components/src/com/google/appinventor/components/runtime/util/AlignmentUtil.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/util/AlignmentUtil.java
@@ -8,6 +8,8 @@ package com.google.appinventor.components.runtime.util;
 
 import android.view.Gravity;
 import com.google.appinventor.components.common.ComponentConstants;
+import com.google.appinventor.components.common.HorizontalAlignment;
+import com.google.appinventor.components.common.VerticalAlignment;
 import com.google.appinventor.components.runtime.LinearLayout;
 
 /**
@@ -27,7 +29,7 @@ public class AlignmentUtil {
    * Throws an IllegalArgumentException if alignment has illegal value.
    * @param alignment
    */
-  public void setHorizontalAlignment (int alignment) throws IllegalArgumentException {
+  public void setHorizontalAlignment(int alignment) throws IllegalArgumentException {
     switch (alignment) {
       case ComponentConstants.GRAVITY_LEFT:
         viewLayout.setHorizontalGravity(Gravity.LEFT);
@@ -44,11 +46,29 @@ public class AlignmentUtil {
   }
 
   /**
+   * Sets the horizontal alignment of the view layout.
+   * @param alignment the alignment to set the view layout to.
+   */
+  public void setHorizontalAlignment(HorizontalAlignment alignment) {
+    switch (alignment) {
+      case Left:
+        viewLayout.setHorizontalGravity(Gravity.LEFT);
+        break;
+      case Center:
+        viewLayout.setHorizontalGravity(Gravity.CENTER_HORIZONTAL);
+        break;
+      case Right:
+        viewLayout.setHorizontalGravity(Gravity.RIGHT);
+        break;
+    }
+  }
+
+  /**
    * Set the vertical alignment (gravity) of the alignment
    * Throws an IllegalArgumentException if alignment has illegal value.
    * @param alignment
    */
-  public void setVerticalAlignment (int alignment) throws IllegalArgumentException {
+  public void setVerticalAlignment(int alignment) throws IllegalArgumentException {
     switch (alignment) {
       case ComponentConstants.GRAVITY_TOP:
         viewLayout.setVerticalGravity(Gravity.TOP);
@@ -61,6 +81,20 @@ public class AlignmentUtil {
         break;
       default:
         throw new IllegalArgumentException("Bad value to setVerticalAlignment: " + alignment);
+    }
+  }
+
+  public void setVerticalAlignment(VerticalAlignment alignment) {
+    switch (alignment) {
+      case Top:
+        viewLayout.setVerticalGravity(Gravity.TOP);
+        break;
+      case Center:
+        viewLayout.setVerticalGravity(Gravity.CENTER_VERTICAL);
+        break;
+      case Bottom:
+        viewLayout.setVerticalGravity(Gravity.BOTTOM);
+        break;
     }
   }
 }

--- a/appinventor/docs/markdown/reference/components/layout.md
+++ b/appinventor/docs/markdown/reference/components/layout.md
@@ -58,7 +58,7 @@ Table of Contents:
 
 {:id="HorizontalArrangement.AlignVertical" .number} *AlignVertical*
 : A number that encodes how the contents of the `HorizontalArrangement` are aligned vertically. The choices
- are: `1` = aligned at the top, `2` = aligned at the bottom, `3` = vertically centered.
+ are: `1` = aligned at the top, `2` = vertically centered, `3` = aligned at the bottom.
  Alignment has no effect if the `HorizontalArrangement`'s [`Height`](#HorizontalArrangement.Height) is `Automatic`.
 
 {:id="HorizontalArrangement.BackgroundColor" .color} *BackgroundColor*
@@ -120,7 +120,7 @@ A formatting element in which to place components that should be displayed from 
 
 {:id="HorizontalScrollArrangement.AlignVertical" .number} *AlignVertical*
 : A number that encodes how the contents of the `HorizontalScrollArrangement` are aligned vertically. The choices
- are: `1` = aligned at the top, `2` = aligned at the bottom, `3` = vertically centered.
+ are: `1` = aligned at the top, `2` = vertically centered, `3` = aligned at the bottom.
  Alignment has no effect if the `HorizontalScrollArrangement`'s [`Height`](#HorizontalScrollArrangement.Height) is `Automatic`.
 
 {:id="HorizontalScrollArrangement.BackgroundColor" .color} *BackgroundColor*
@@ -270,7 +270,7 @@ None
 
 {:id="VerticalArrangement.AlignVertical" .number} *AlignVertical*
 : A number that encodes how the contents of the `VerticalArrangement` are aligned vertically. The choices
- are: `1` = aligned at the top, `2` = aligned at the bottom, `3` = vertically centered.
+ are: `1` = aligned at the top, `2` = vertically centered, `3` = aligned at the bottom.
  Alignment has no effect if the `VerticalArrangement`'s [`Height`](#VerticalArrangement.Height) is `Automatic`.
 
 {:id="VerticalArrangement.BackgroundColor" .color} *BackgroundColor*
@@ -332,7 +332,7 @@ A formatting element in which to place components that should be displayed one b
 
 {:id="VerticalScrollArrangement.AlignVertical" .number} *AlignVertical*
 : A number that encodes how the contents of the `VerticalScrollArrangement` are aligned vertically. The choices
- are: `1` = aligned at the top, `2` = aligned at the bottom, `3` = vertically centered.
+ are: `1` = aligned at the top, `2` = vertically centered, `3` = aligned at the bottom.
  Alignment has no effect if the `VerticalScrollArrangement`'s [`Height`](#VerticalScrollArrangement.Height) is `Automatic`.
 
 {:id="VerticalScrollArrangement.BackgroundColor" .color} *BackgroundColor*

--- a/appinventor/docs/markdown/reference/components/maps.md
+++ b/appinventor/docs/markdown/reference/components/maps.md
@@ -82,7 +82,7 @@ The `Circle` component visualizes a circle of a given [`Radius`](#Circle.Radius)
  map feature.
 
 {:id="Circle.Type" .text .ro .bo} *Type*
-: Returns the type of the feature. For Circles, this returns the text "Circle".
+: Returns the type of the feature. For Circles, this returns MapFeature.Circle ("Circle").
 
 {:id="Circle.Visible" .boolean} *Visible*
 : Specifies whether the `Circle` should be visible on the screen.  Value is `true`{:.logic.block}
@@ -305,7 +305,7 @@ A `FeatureCollection` groups one or more map features together. Any events that 
  map feature.
 
 {:id="LineString.Type" .text .ro .bo} *Type*
-: Returns the type of the map feature. For LineString, this returns the text "LineString".
+: Returns the type of the map feature. For LineString, this returns MapFeature.LineString ("LineString").
 
 {:id="LineString.Visible" .boolean} *Visible*
 : Specifies whether the `LineString` should be visible on the screen.  Value is `true`{:.logic.block}
@@ -885,7 +885,7 @@ The Navigation component generates directions between two locations using a serv
  map feature.
 
 {:id="Polygon.Type" .text .ro .bo} *Type*
-: Returns the type of the feature. For polygons, this returns the text "Polygon".
+: Returns the type of the feature. For polygons, this returns MapFeature.Polygon ("Polygon").
 
 {:id="Polygon.Visible" .boolean} *Visible*
 : Specifies whether the `Polygon` should be visible on the screen.  Value is `true`{:.logic.block}
@@ -995,7 +995,7 @@ The Navigation component generates directions between two locations using a serv
  map feature.
 
 {:id="Rectangle.Type" .text .ro .bo} *Type*
-: Returns the type of the feature. For rectangles, this returns the text "Rectangle".
+: Returns the type of the feature. For rectangles, this returns MapFeature.Rectangle ("Rectangle").
 
 {:id="Rectangle.Visible" .boolean} *Visible*
 : Specifies whether the `Rectangle` should be visible on the screen.  Value is `true`{:.logic.block}

--- a/appinventor/docs/markdown/reference/components/userinterface.md
+++ b/appinventor/docs/markdown/reference/components/userinterface.md
@@ -943,7 +943,7 @@ Top-level component containing all other components in the program.
 
 {:id="Screen.AlignHorizontal" .number} *AlignHorizontal*
 : A number that encodes how contents of the screen are aligned horizontally. The choices are:
- `1` (left aligned), `2` (horizontally centered), `3` (right aligned).
+ `1` (left aligned), `3` (horizontally centered), `2` (right aligned).
 
 {:id="Screen.AlignVertical" .number} *AlignVertical*
 : A number that encodes how the contents of the arrangement are aligned vertically. The choices
@@ -979,8 +979,7 @@ Top-level component containing all other components in the program.
  The build server will generate images of standard dimensions for Android devices.
 
 {:id="Screen.OpenScreenAnimation" .text} *OpenScreenAnimation*
-: The animation for switching to another screen. Valid options are `default`, `fade`, `zoom`,
- `slidehorizontal`, `slidevertical`, and `none`.
+: Sets the animation type for the transition of this form opening.
 
 {:id="Screen.Platform" .text .ro .bo} *Platform*
 : Gets the name of the underlying platform running the app. Currently, this is the text


### PR DESCRIPTION
### Description

Depends on #8 

This ended up being a lot easier than I thought it would be. All of the components that use horizontal and vertical alignment use the following values:

Horizontal
* Left (1)
* Center (3)
* Right (2)

Vertical
* Top (1)
* Center (2)
* Bottom (3)

The problem was that the docs were really messed up.

So I've added support for alignment in the Form (Screen), Marker, and Arrangement components.

### Testing

Tested that all of the blocks properly appear in the drawer.

I also tested setting each property using the dropdown block and the Do It feature.

### Recommended Method for Review
Commit-wise.