### PR TITLE
Add PhoneCall and Texting component enums

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1590,6 +1590,10 @@ public final class YoungAndroidFormUpgrader {
     if (srcCompVersion < 4) {
       srcCompVersion = 4;
     }
+    if (srcCompVersion < 5) {
+      // Adds ReceivingState dropdown block.
+      srcCompVersion = 5;
+    }
 
     return srcCompVersion;
   }

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2683,7 +2683,11 @@ Blockly.Versioning.AllUpgradeMaps =
     */
     3: "ai1CantDoUpgrade", // Just indicates we couldn't do upgrade even if we wanted to
 
-    4: 'noUpgrade'
+    4: 'noUpgrade',
+
+    // Adds ReceivingState dropdown block.
+    5: Blockly.Versioning.makeSetterUseDropdown(
+        'Texting', 'ReceivingEnabled', 'ReceivingState')
 
   }, // End Texting
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2687,7 +2687,7 @@ Blockly.Versioning.AllUpgradeMaps =
 
     // Adds ReceivingState dropdown block.
     5: Blockly.Versioning.makeSetterUseDropdown(
-        'Texting', 'ReceivingEnabled', 'ReceivingState')
+         'Texting', 'ReceivingEnabled', 'ReceivingState')
 
   }, // End Texting
 

--- a/appinventor/components/src/com/google/appinventor/components/common/EndedStatus.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/EndedStatus.java
@@ -1,0 +1,40 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a EndedStatus type used by the PhoneCall component.
+ */
+public enum EndedStatus implements OptionList<Integer> {
+  IncomingRejected(1),
+  IncomingEnded(2),
+  OutgoingEnded(3);
+
+  private int value;
+
+  EndedStatus(int status) {
+    this.value = status;
+  }
+
+  public Integer toUnderlyingValue() {
+    return value;
+  }
+
+  private static final Map<Integer, EndedStatus> lookup = new HashMap<>();
+
+  static {
+    for(EndedStatus status : EndedStatus.values()) {
+      lookup.put(status.toUnderlyingValue(), status);
+    }
+  }
+
+  public static EndedStatus fromUnderlyingValue(Integer status) {
+    return lookup.get(status);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/ReceivingState.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/ReceivingState.java
@@ -1,0 +1,40 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a ReceivingState type used by the Texting component.
+ */
+public enum ReceivingState implements OptionList<Integer> {
+  Off(1),
+  Foreground(2),
+  Always(3);
+
+  private int value;
+
+  ReceivingState(int status) {
+    this.value = status;
+  }
+
+  public Integer toUnderlyingValue() {
+    return value;
+  }
+
+  private static final Map<Integer, ReceivingState> lookup = new HashMap<>();
+
+  static {
+    for(ReceivingState status : ReceivingState.values()) {
+      lookup.put(status.toUnderlyingValue(), status);
+    }
+  }
+
+  public static ReceivingState fromUnderlyingValue(Integer status) {
+    return lookup.get(status);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/StartedStatus.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/StartedStatus.java
@@ -1,0 +1,39 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a StartedStatus type used by the PhoneCall component.
+ */
+public enum StartedStatus implements OptionList<Integer> {
+  Incoming(1),
+  Outgoing(2);
+
+  private int value;
+
+  StartedStatus(int status) {
+    this.value = status;
+  }
+
+  public Integer toUnderlyingValue() {
+    return value;
+  }
+
+  private static final Map<Integer, StartedStatus> lookup = new HashMap<>();
+
+  static {
+    for(StartedStatus status : StartedStatus.values()) {
+      lookup.put(status.toUnderlyingValue(), status);
+    }
+  }
+
+  public static StartedStatus fromUnderlyingValue(Integer status) {
+    return lookup.get(status);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1213,7 +1213,9 @@ public class YaVersion {
   //   conditional permissions
   // - The SendMessage method was added
   // - The ReceivingEnabled method was given conditional permissions
-  public static final int TEXTING_COMPONENT_VERSION = 4;
+  // For TEXTING_COMPONENT_VERSION 5:
+  // - Adds ReceivingState dropdown block.
+  public static final int TEXTING_COMPONENT_VERSION = 5;
 
   // For TEXTTOSPEECH_COMPONENT_VERSION 2:
   // - added speech pitch and rate

--- a/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
@@ -19,6 +19,7 @@ import android.net.Uri;
 import android.telephony.TelephonyManager;
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
@@ -26,7 +27,9 @@ import com.google.appinventor.components.annotations.SimpleObject;
 import com.google.appinventor.components.annotations.SimpleProperty;
 import com.google.appinventor.components.annotations.UsesPermissions;
 import com.google.appinventor.components.common.ComponentCategory;
+import com.google.appinventor.components.common.EndedStatus;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.StartedStatus;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.BulkPermissionRequest;
 import com.google.appinventor.components.runtime.util.PhoneCallUtil;
@@ -198,9 +201,19 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
       READ_CALL_LOG,  // minSDK 16, needed on SDK 29
       READ_PHONE_STATE
   })
-  public void PhoneCallStarted(int status, String phoneNumber) {
-    // invoke the application's "PhoneCallStarted" event handler.
-    EventDispatcher.dispatchEvent(this, "PhoneCallStarted", status, phoneNumber);
+  public void PhoneCallStarted(@Options(StartedStatus.class) int status, String phoneNumber) {
+    // Make sure status is a valid StartedStatus.
+    StartedStatus startedStatus = StartedStatus.fromUnderlyingValue(status);
+    if (startedStatus != null) {
+      PhoneCallStartedAbstract(startedStatus, phoneNumber);
+    }
+  }
+
+  /**
+   * Dispatches the PhoneCallStarted event.
+   */
+  public void PhoneCallStartedAbstract(StartedStatus status, String phoneNumber) {
+    EventDispatcher.dispatchEvent(this, "PhoneCallStarted", status.toUnderlyingValue(), phoneNumber);
   }
 
   /**
@@ -226,9 +239,19 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
       READ_CALL_LOG,  // minSDK 16, needed on SDK 29
       READ_PHONE_STATE,
   })
-  public void PhoneCallEnded(int status, String phoneNumber) {
-    // invoke the application's "PhoneCallEnded" event handler.
-    EventDispatcher.dispatchEvent(this, "PhoneCallEnded", status, phoneNumber);
+  public void PhoneCallEnded(@Options(EndedStatus.class) int status, String phoneNumber) {
+    // Make sure status is a valid EndedStatus.
+    EndedStatus endedStatus = EndedStatus.fromUnderlyingValue(status);
+    if (endedStatus != null) {
+      PhoneCallEndedAbstract(endedStatus, phoneNumber);
+    }
+  }
+
+  /**
+   * Dispatched the PhoneCallEnded event.
+   */
+  public void PhoneCallEndedAbstract(EndedStatus status, String phoneNumber) {
+    EventDispatcher.dispatchEvent(this, "PhoneCallEnded", status.toUnderlyingValue(), phoneNumber);
   }
 
   /**
@@ -254,8 +277,14 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
   @Override
   public void resultReturned(int requestCode, int resultCode, Intent data) {
     if (requestCode == PHONECALL_REQUEST_CODE) {
-      PhoneCallStarted(2, "");
+      PhoneCallStartedAbstract(StartedStatus.Outgoing, "");
     }
+  }
+
+  private enum CallStatus {
+    INCOMING_WAITING,
+    INCOMING_ANSWERED,
+    OUTGOING_WAITING,
   }
 
   /**
@@ -263,11 +292,13 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
    *
    */
   private class CallStateReceiver extends BroadcastReceiver {
-    private int status; // 0:undetermined, 1:incoming ringed, 2:outgoing dialled,
+
+    private CallStatus status; // 0:undetermined, 1:incoming ringed, 2:outgoing dialled,
                         // 3: incoming answered
-    private String number; // phone call number
+    private String number;
+
     public CallStateReceiver() {
-      status = 0;
+      status = null;
       number = "";
     }
 
@@ -277,42 +308,34 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
       if(TelephonyManager.ACTION_PHONE_STATE_CHANGED.equals(action)){
         String state = intent.getStringExtra(TelephonyManager.EXTRA_STATE);
         if(TelephonyManager.EXTRA_STATE_RINGING.equals(state)){
-          // Incoming call rings
-          status = 1;
+          status = CallStatus.INCOMING_WAITING;
           number = intent.getStringExtra(TelephonyManager.EXTRA_INCOMING_NUMBER);
           if (number == null) {
             // This gets called first with null, then with the actual number.
             // Ignore the first invocation.
             return;
           }
-          PhoneCallStarted(1, number);
-        }else if(TelephonyManager.EXTRA_STATE_OFFHOOK.equals(state)){
-          // Call off-hook
-          if(status == 1){
-            // Incoming call answered
-            status = 3;
+          PhoneCallStartedAbstract(StartedStatus.Incoming, number);
+        } else if (TelephonyManager.EXTRA_STATE_OFFHOOK.equals(state)){
+          if(status == CallStatus.INCOMING_WAITING){
+            status = CallStatus.INCOMING_ANSWERED;
             IncomingCallAnswered(number);
           }
-        }else if(TelephonyManager.EXTRA_STATE_IDLE.equals(state)){
-          // Incomming/Outgoing Call ends
-          if(status == 1){
-            // Incoming Missed or Rejected
-            PhoneCallEnded(1, number);
-          }else if(status == 3){
-            // Incoming Answer Ended
-            PhoneCallEnded(2, number);
-          }else if(status == 2){
-            // Outgoing Ended
-            PhoneCallEnded(3, number);
+        } else if (TelephonyManager.EXTRA_STATE_IDLE.equals(state)) { // Incoming/Outgoing Call ends
+          if (status == CallStatus.INCOMING_WAITING) {
+            PhoneCallEndedAbstract(EndedStatus.IncomingRejected, number);
+          } else if (status == CallStatus.INCOMING_ANSWERED) {
+            PhoneCallEndedAbstract(EndedStatus.IncomingEnded, number);
+          } else if(status == CallStatus.OUTGOING_WAITING) {
+            PhoneCallEndedAbstract(EndedStatus.OutgoingEnded, number);
           }
-          status = 0;
+          status = null;
           number = "";
         }
-      }else if(Intent.ACTION_NEW_OUTGOING_CALL.equals(action)){
-        // Outgoing call dialled
-        status = 2;
+      } else if (Intent.ACTION_NEW_OUTGOING_CALL.equals(action)) {
+        status = CallStatus.OUTGOING_WAITING;
         number = intent.getStringExtra(Intent.EXTRA_PHONE_NUMBER);
-        PhoneCallStarted(2, number);
+        PhoneCallStartedAbstract(StartedStatus.Outgoing, number);
       }
     }
   }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/PhoneCall.java
@@ -293,8 +293,13 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
    */
   private class CallStateReceiver extends BroadcastReceiver {
 
-    private CallStatus status; // 0:undetermined, 1:incoming ringed, 2:outgoing dialled,
-                        // 3: incoming answered
+    /**
+     * Defines the current status of the call.
+     * 1: Incoming ringed
+     * 2: Outgoing dialled
+     * 3: Incoming answered
+     */
+    private CallStatus status;
     private String number;
 
     public CallStateReceiver() {
@@ -305,9 +310,9 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
     @Override
     public void onReceive(Context context, Intent intent) {
       String action = intent.getAction();
-      if(TelephonyManager.ACTION_PHONE_STATE_CHANGED.equals(action)){
+      if (TelephonyManager.ACTION_PHONE_STATE_CHANGED.equals(action)) {
         String state = intent.getStringExtra(TelephonyManager.EXTRA_STATE);
-        if(TelephonyManager.EXTRA_STATE_RINGING.equals(state)){
+        if (TelephonyManager.EXTRA_STATE_RINGING.equals(state)) {
           status = CallStatus.INCOMING_WAITING;
           number = intent.getStringExtra(TelephonyManager.EXTRA_INCOMING_NUMBER);
           if (number == null) {
@@ -316,8 +321,8 @@ public class PhoneCall extends AndroidNonvisibleComponent implements Component, 
             return;
           }
           PhoneCallStartedAbstract(StartedStatus.Incoming, number);
-        } else if (TelephonyManager.EXTRA_STATE_OFFHOOK.equals(state)){
-          if(status == CallStatus.INCOMING_WAITING){
+        } else if (TelephonyManager.EXTRA_STATE_OFFHOOK.equals(state)) {
+          if (status == CallStatus.INCOMING_WAITING) {
             status = CallStatus.INCOMING_ANSWERED;
             IncomingCallAnswered(number);
           }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Texting.java
@@ -37,6 +37,7 @@ import com.google.appinventor.components.runtime.util.SmsBroadcastReceiver;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.annotations.PropertyCategory;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
@@ -51,6 +52,7 @@ import com.google.appinventor.components.annotations.androidmanifest.ReceiverEle
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.ComponentConstants;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.ReceivingState;
 import com.google.appinventor.components.common.YaVersion;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 
@@ -213,7 +215,7 @@ public class Texting extends AndroidNonvisibleComponent
   private String authToken;
 
   // Indicates whether the component is receiving messages or not
-  private static int receivingEnabled = ComponentConstants.TEXT_RECEIVING_FOREGROUND;
+  private static ReceivingState receivingState = ReceivingState.Foreground;
   private SmsManager smsManager;
 
   // The phone number to send the text message to.
@@ -260,19 +262,22 @@ public class Texting extends AndroidNonvisibleComponent
 
     SharedPreferences prefs = activity.getSharedPreferences(PREF_FILE, Activity.MODE_PRIVATE);
     if (prefs != null) {
-      receivingEnabled = prefs.getInt(PREF_RCVENABLED, -1);
-      if (receivingEnabled == -1) {
+      int pref = prefs.getInt(PREF_RCVENABLED, -1);
+      if (pref == -1) {
         if (prefs.getBoolean(PREF_RCVENABLED_LEGACY, true)) {
-          receivingEnabled = ComponentConstants.TEXT_RECEIVING_FOREGROUND;
+          receivingState = ReceivingState.Foreground;
         } else {
-          receivingEnabled = ComponentConstants.TEXT_RECEIVING_OFF;
+          receivingState = ReceivingState.Off;
         }
+      } else {
+        receivingState = ReceivingState.fromUnderlyingValue(pref);
       }
 
       googleVoiceEnabled = prefs.getBoolean(PREF_GVENABLED, false);
-      Log.i(TAG, "Starting with receiving Enabled=" + receivingEnabled + " GV enabled=" + googleVoiceEnabled);
+      Log.i(TAG, "Starting with receiving Enabled=" + receivingState.toUnderlyingValue() +
+          " GV enabled=" + googleVoiceEnabled);
     } else {
-      receivingEnabled = ComponentConstants.TEXT_RECEIVING_OFF;
+      receivingState = ReceivingState.Off;
       googleVoiceEnabled = false;
     }
 
@@ -310,7 +315,7 @@ public class Texting extends AndroidNonvisibleComponent
 
   // Called from runtime.scm
   public void Initialize() {
-    if (receivingEnabled > ComponentConstants.TEXT_RECEIVING_OFF && !haveReceivePermission) {
+    if (receivingState != ReceivingState.Off && !haveReceivePermission) {
       // Request receive SMS permission if we are configured to receive but do not have permission
       requestReceiveSmsPermission("Initialize");
     }
@@ -455,15 +460,16 @@ public class Texting extends AndroidNonvisibleComponent
    */
   @SimpleEvent
   public static void MessageReceived(String number, String messageText) {
-    if (receivingEnabled > ComponentConstants.TEXT_RECEIVING_OFF) {
-      Log.i(TAG, "MessageReceived from " + number + ":" + messageText);
-      if (EventDispatcher.dispatchEvent(component, "MessageReceived", number, messageText)) {
-        Log.i(TAG, "Dispatch successful");
-      } else {
-        Log.i(TAG, "Dispatch failed, caching");
-        synchronized (cacheLock) {
-          addMessageToCache(activity, number, messageText);
-        }
+    if (receivingState == ReceivingState.Off) {
+      return;
+    }
+    Log.i(TAG, "MessageReceived from " + number + ":" + messageText);
+    if (EventDispatcher.dispatchEvent(component, "MessageReceived", number, messageText)) {
+      Log.i(TAG, "Dispatch successful");
+    } else {
+      Log.i(TAG, "Dispatch failed, caching");
+      synchronized (cacheLock) {
+        addMessageToCache(activity, number, messageText);
       }
     }
   }
@@ -538,8 +544,15 @@ public class Texting extends AndroidNonvisibleComponent
     "appear when the app awakens.  As an app developer, it would be a good " +
     "idea to give your users control over this property, so they can make " +
     "their phones ignore text messages when your app is installed.")
-  public int ReceivingEnabled() {
-    return receivingEnabled;
+  public @Options(ReceivingState.class) int ReceivingEnabled() {
+    return receivingState.toUnderlyingValue();
+  }
+
+  /**
+   * Returns the texting components current state of receiving for messages.
+   */
+  public ReceivingState ReceivingEnabledAbstract() {
+    return receivingState;
   }
 
   /**
@@ -569,21 +582,28 @@ public class Texting extends AndroidNonvisibleComponent
               })
           })
   })
-  public void ReceivingEnabled(int enabled) {
-    if ((enabled < ComponentConstants.TEXT_RECEIVING_OFF) ||
-        (enabled > ComponentConstants.TEXT_RECEIVING_ALWAYS)) {
+  public void ReceivingEnabled(@Options(ReceivingState.class) int enabled) {
+    // Make sure enabled is a valid ReceivingState.
+    ReceivingState state = ReceivingState.fromUnderlyingValue(enabled);
+    if (state == null) {
       container.$form().dispatchErrorOccurredEvent(this, "Texting",
           ErrorMessages.ERROR_BAD_VALUE_FOR_TEXT_RECEIVING, enabled);
       return;
     }
+    ReceivingEnabledAbstract(state);
+  }
 
-    Texting.receivingEnabled = enabled;
+  /**
+   * Sets the current state of receiving messages for this component.
+   */
+  public void ReceivingEnabledAbstract(ReceivingState state) {
+    Texting.receivingState = state;
     SharedPreferences prefs = activity.getSharedPreferences(PREF_FILE, Activity.MODE_PRIVATE);
     SharedPreferences.Editor editor = prefs.edit();
-    editor.putInt(PREF_RCVENABLED, enabled);
+    editor.putInt(PREF_RCVENABLED, state.toUnderlyingValue());
     editor.remove(PREF_RCVENABLED_LEGACY); // Remove any legacy value
     editor.commit();
-    if (enabled > ComponentConstants.TEXT_RECEIVING_OFF && !haveReceivePermission) {
+    if (state != ReceivingState.Off && !haveReceivePermission) {
       requestReceiveSmsPermission("ReceivingEnabled");
     }
   }
@@ -647,7 +667,7 @@ public class Texting extends AndroidNonvisibleComponent
       int delim = phoneAndMessage.indexOf(":");
 
       // If receiving is not enabled, messages are not dispatched
-      if ((receivingEnabled > ComponentConstants.TEXT_RECEIVING_OFF) && delim != -1) {
+      if (receivingState != ReceivingState.Off && delim != -1) {
         MessageReceived(phoneAndMessage.substring(0,delim),
             phoneAndMessage.substring(delim+1));
       }
@@ -1223,7 +1243,7 @@ public class Texting extends AndroidNonvisibleComponent
   public void onStop() {
     SharedPreferences prefs = activity.getSharedPreferences(PREF_FILE, Activity.MODE_PRIVATE);
     SharedPreferences.Editor editor = prefs.edit();
-    editor.putInt(PREF_RCVENABLED, receivingEnabled);
+    editor.putInt(PREF_RCVENABLED, receivingState.toUnderlyingValue());
     editor.putBoolean(PREF_GVENABLED, googleVoiceEnabled);
     editor.commit();
   }


### PR DESCRIPTION
### Description

Depends on #6

Added EndedStatus and StartedStatus for the PhoneCall component. Added ReceivingState for the Texting component.

### Testing

I had trouble testing this one because I couldn't get the PhoneCall events to fire (even on the released version of App Inventor). I also couldn't get the Texting events to fire on either version. I'm not sure if this is something I'm doing wrong, or it's a bug.

But the blocks do show up, and for the Texting component at least the values seem to be getting handled correctly.

### Recommended Method for Review
Commit-Wise
