### PR TITLE
Implement Stage 2

### DIFF
--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -1233,7 +1233,7 @@ Blockly.Blocks.component_set_get = {
     var helperType = Blockly.Blocks.Utilities
         .helperKeyToBlocklyType(property.helperKey, this);
     if (helperType && helperType != blocklyType) {
-        check.push(helperType);
+      check.push(helperType);
     }
 
     return !check.length ? null : check;

--- a/appinventor/blocklyeditor/src/blocks/components.js
+++ b/appinventor/blocklyeditor/src/blocks/components.js
@@ -815,10 +815,11 @@ Blockly.Blocks.component_method = {
     var check = [];
 
     var blocklyType = Blockly.Blocks.Utilities.YailTypeToBlocklyType(
-        param.type, Blockly.Blocks.Utilities.Input);
+        param.type, Blockly.Blocks.Utilities.INPUT);
     if (blocklyType) {
       if (Array.isArray(blocklyType)) {
-        check = blocklyType;
+        // Clone array.
+        check = blocklyType.slice();
       } else {
         check.push(blocklyType);
       }
@@ -829,6 +830,28 @@ Blockly.Blocks.component_method = {
     if (helperType && helperType != blocklyType) {
       check.push(helperType);
     }
+    return !check.length ? null : check;
+  },
+
+  getReturnBlocklyType : function(methodObj) {
+    var check = [];
+    var blocklyType = Blockly.Blocks.Utilities.YailTypeToBlocklyType(
+        methodObj.returnType, Blockly.Blocks.Utilities.OUTPUT);
+    if (blocklyType) {
+      if (Array.isArray(blocklyType)) {
+        // Clone array.
+        check = blocklyType.slice();
+      } else {
+        check.push(blocklyType);
+      }
+    }
+
+    var helperType = Blockly.Blocks.Utilities
+        .helperKeyToBlocklyType(methodObj.returnHelperKey, this);
+    if (helperType && helperType != blocklyType) {
+      check.push(helperType);
+    }
+
     return !check.length ? null : check;
   },
 
@@ -949,7 +972,7 @@ Blockly.Blocks.component_method = {
           modifiedReturnType = true; // missing return type
         }
         else {
-          this.outputConnection.setCheck(Blockly.Blocks.Utilities.YailTypeToBlocklyType(method.returnType,Blockly.Blocks.Utilities.OUTPUT));
+          this.outputConnection.setCheck(this.getReturnBlocklyType(method));
         }
       }
       else if (!method.returnType) {
@@ -1200,22 +1223,17 @@ Blockly.Blocks.component_set_get = {
         .YailTypeToBlocklyType(yailType, inputOrOutput);
     if (blocklyType) {
       if (Array.isArray(blocklyType)) {
-        check = blocklyType;
+        // Clone array.
+        check = blocklyType.slice();
       } else {
         check.push(blocklyType);
       }
     }
 
-    // Aka if this is a setter. We don't want blockly to think properties that
-    // return strings but accept options actually return options. Once we add
-    // support for sanitizing returned values to their enum types, this will
-    // change.
-    if (inputOrOutput == Blockly.Blocks.Utilities.INPUT) {
-      var helperType = Blockly.Blocks.Utilities
-          .helperKeyToBlocklyType(property.helperKey, this);
-      if (helperType && helperType != blocklyType) {
-          check.push(helperType);
-      }
+    var helperType = Blockly.Blocks.Utilities
+        .helperKeyToBlocklyType(property.helperKey, this);
+    if (helperType && helperType != blocklyType) {
+        check.push(helperType);
     }
 
     return !check.length ? null : check;

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -1,8 +1,7 @@
 // -*- mode: java; c-basic-offset: 2; -*-
-// Copyright 2013-2014 MIT, All rights reserved
+// Copyright 2020 MIT, All rights reserved
 // Released under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
-
 
 /**
  * @license

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -38,9 +38,6 @@ Blockly.Blocks['helpers_dropdown'] = {
 
   domToMutation: function(xml) {
     this.key_ = xml.getAttribute('key');
-    var type = Blockly.Blocks.Utilities.helperKeyToBlocklyType(
-      { type: 'OPTION_LIST', key: this.key_ }, this);
-    this.setOutput(true, type);
 
     var db = this.getTopWorkspace().getComponentDatabase();
     var optionList = db.getOptionList(this.key_);
@@ -52,13 +49,35 @@ Blockly.Blocks['helpers_dropdown'] = {
     // to connect to inputs which expect its specific type of enum. Currently
     // this is only used for Blockly connection checks, as no output types are
     // encoded in Yail.
-    this.setOutput(true, type);
+    this.setOutput(true, this.getOutputType());
     this.appendDummyInput()
         .appendField(tag)
         .appendField(dropdown, 'OPTION');
     
     var value = xml.getAttribute('value') || optionList.defaultOpt;
     this.setFieldValue(value, 'OPTION');
+  },
+
+  getOutputType: function() {
+    var check = [];
+    var blocklyType = Blockly.Blocks.Utilities.YailTypeToBlocklyType(
+        'enum', Blockly.Blocks.Utilities.OUTPUT);
+    if (blocklyType) {
+      if (Array.isArray(blocklyType)) {
+        // Clone array.
+        check = blocklyType.slice();
+      } else {
+        check.push(blocklyType);
+      }
+    }
+
+    var helperType = Blockly.Blocks.Utilities.helperKeyToBlocklyType(
+      { type: 'OPTION_LIST', key: this.key_ }, this);
+    if (helperType && helperType != blocklyType) {
+      check.push(helperType);
+    }
+
+    return !check.length ? null : check;
   },
 
   /**

--- a/appinventor/blocklyeditor/src/blocks/utilities.js
+++ b/appinventor/blocklyeditor/src/blocks/utilities.js
@@ -36,7 +36,8 @@ Blockly.Blocks.Utilities.YailTypeToBlocklyTypeMap = {
   'any':{input:null,output:null},
   'dictionary':{input:"Dictionary",output:["Dictionary", "String", "Array"]},
   'pair':{input:"Pair",output:["Pair", "String", "Array"]},
-  'key':{input:"Key",output:["String", "Key"]}
+  'key':{input:"Key",output:["String", "Key"]},
+  'enum':{input:null,output:"Key"}
   //add  more types here
 };
 

--- a/appinventor/blocklyeditor/src/generators/yail/helpers.js
+++ b/appinventor/blocklyeditor/src/generators/yail/helpers.js
@@ -25,7 +25,7 @@ Blockly.Yail['helpers_dropdown'] = function() {
   // does not support OptionLists it will continue to return the concrete value.
   var code = '(protect-enum ' + enumValue + ' ' + concreteValue + ')';
 
-  return [code, Blockly.Yail.ORDER_ATOMIC]
+  return [code, Blockly.Yail.ORDER_ATOMIC];
 }
 
 Blockly.Yail['helpers_screen_names'] = function() {

--- a/appinventor/blocklyeditor/src/generators/yail/helpers.js
+++ b/appinventor/blocklyeditor/src/generators/yail/helpers.js
@@ -12,22 +12,20 @@ Blockly.Yail['helpers_dropdown'] = function() {
     return opt.name == enumConstantName;
   });
 
-  var code = option.value;
+  // See https://www.gnu.org/software/kawa/Enumerations.html
+  var enumValue = optionList.className + ":" + enumConstantName;
+
+  var concreteValue = option.value;
   if (optionList.underlyingType == "java.lang.String") {
-    code = Blockly.Yail.quote_(code);
+    concreteValue = Blockly.Yail.quote_(concreteValue);
   } // Otherwise assume it doesn't need to be quoted.
 
+  // protect-enum is a macro which checks if the companion supports OptionLists
+  // and if it does it will return the abstract enum value. If the companion
+  // does not support OptionLists it will continue to return the concrete value.
+  var code = '(protect-enum ' + enumValue + ' ' + concreteValue + ')';
+
   return [code, Blockly.Yail.ORDER_ATOMIC]
-
-  // TODO: This will be used after we add abstraction.
-  // See https://www.gnu.org/software/kawa/Enumerations.html
-  // var code = optionList.className + ":" + enumConstantName;
-
-  // Currently we are returning the concrete values of the optionList option for
-  // easy backwards compatibility with the companion. But in the future we will
-  // return a macro which checks if the companion supports OptionLists and if
-  // it does it will return the abstract enum value. If the companion does not
-  // support OptionLists it will continue to return the concrete value.
 }
 
 Blockly.Yail['helpers_screen_names'] = function() {

--- a/appinventor/blocklyeditor/src/replmgr.js
+++ b/appinventor/blocklyeditor/src/replmgr.js
@@ -332,6 +332,16 @@ Blockly.ReplMgr.putYail = (function() {
                 console.log('putYail: phone not connected');
                 return;
             }
+
+            // Add the protect-enum macro (used by dropdown blocks).
+            code += "(define-syntax protect-enum " +
+                "  (lambda (x) "+
+                "    (syntax-case x () " +
+                "      ((_ enum-value number-value) " +
+                "        (if (< com.google.appinventor.components.common.YaVersion:BLOCKS_LANGUAGE_VERSION 33) " +
+                "          #'number-value " +
+                "          #'enum-value)))))";
+
             if (!rs.phoneState.phoneQueue) {
                 rs.phoneState.phoneQueue = [];
             }

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -742,6 +742,14 @@
        #`(begin
            (define-event-helper ,(gen-generic-event-name #`component-type #`event-name) args body))))))
 
+
+(define-syntax protect-enum
+  (lambda (x)
+    (syntax-case x ()
+      ((_ enum-value number-value)
+       (if (< com.google.appinventor.components.common.YaVersion:BLOCKS_LANGUAGE_VERSION 33)
+           #'number-value
+           #'enum-value)))))
 ;;;; def
 
 ;;; Def here is putting things (1) in the form environment; (2) in a

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -1194,11 +1194,11 @@
 (define (sanitize-return-value component func-name value)
   (define-alias OptionHelper com.google.appinventor.components.runtime.OptionHelper)
   (if (enum? value)
-      value
-      (let ((value (OptionHelper:optionListFromValue component func-name value)))
+    value
+    (let ((value (OptionHelper:optionListFromValue component func-name value)))
       (if (enum? value)
-          value
-          (sanitize-component-data value)))))
+        value
+        (sanitize-component-data value)))))
 
 ;;; If we are handed a collection that contains a yail list as an item,
 ;;; then the result of converting it to a kawa list will be a kawa list that
@@ -2584,16 +2584,16 @@ Dictionary implementation.
 (define (yail-dictionary-lookup key yail-dictionary default)
   (let ((result
     (cond ((instance? yail-dictionary YailList)
-           (yail-alist-lookup key yail-dictionary default))
+            (yail-alist-lookup key yail-dictionary default))
           ((instance? yail-dictionary YailDictionary)
             (*:get (as YailDictionary yail-dictionary) key))
           (#t default))))
     (if (eq? result #!null)
-        ;; if we don't find anything associated with the abstract type, try the underlying type.
-        (if (enum? key)
-            (yail-dictionary-lookup (sanitize-component-data (key:toUnderlyingValue)) yail-dictionary default)
-            default)
-        result)))
+      ;; if we don't find anything associated with the abstract type, try the underlying type.
+      (if (enum? key)
+        (yail-dictionary-lookup (sanitize-component-data (key:toUnderlyingValue)) yail-dictionary default)
+        default)
+      result)))
 
 (define (yail-dictionary-recursive-lookup keys yail-dictionary default)
   (let ((result (*:getObjectAtKeyPath (as YailDictionary yail-dictionary) (yail-list-contents keys))))

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -1691,10 +1691,6 @@
 
 (define (yail-atomic-equal? x1 x2)
   (cond
-   ;; enums must be coerced to their underlying values for backwards compatibility.
-   ((enum? x1) (yail-atomic-equal? (x1:toUnderlyingValue) x2))
-   ((enum? x2) (yail-atomic-equal? x1 (x2:toUnderlyingValue)))
-
    ;; equal? covers the case where x1 and x2 are equal objects or equal strings.
    ((equal? x1 x2) #t)
    ;; This implementation says that "0" is equal to "00" since
@@ -1707,6 +1703,9 @@
    ;; Uncomment these two lines to use string=? on strings
    ;; ((and (string? x1) (string? x2))
    ;;  (equal? x1 x2))
+
+   ((and (enum? x1) (not (enum? x2))) (equal? (x1:toUnderlyingValue) x2))
+   ((and (not (enum? x1)) (enum? x2)) (equal? x1 (x2:toUnderlyingValue)))
 
    ;; If the x1 and x2 are not equal?, try comparing coverting x1 and x2 to numbers
    ;; and comparing them numerically

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -1454,6 +1454,7 @@
    ;;;   arg if (number? arg) is true. So why don't we just return arg here?
    ((number? arg) (coerce-to-number arg))
    ((string? arg) (coerce-to-string arg))
+   ((enum? arg) arg)
    ((instance? arg com.google.appinventor.components.runtime.Component) arg)
    (else *non-coercible-value*)))
 
@@ -2589,8 +2590,11 @@ Dictionary implementation.
             (*:get (as YailDictionary yail-dictionary) key))
           (#t default))))
     (if (eq? result #!null)
-      default
-      result)))
+        ;; if we don't find anything associated with the abstract type, try the underlying type.
+        (if (enum? key)
+            (yail-dictionary-lookup (sanitize-component-data (key:toUnderlyingValue)) yail-dictionary default)
+            default)
+        result)))
 
 (define (yail-dictionary-recursive-lookup keys yail-dictionary default)
   (let ((result (*:getObjectAtKeyPath (as YailDictionary yail-dictionary) (yail-list-contents keys))))

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -743,13 +743,6 @@
            (define-event-helper ,(gen-generic-event-name #`component-type #`event-name) args body))))))
 
 
-(define-syntax protect-enum
-  (lambda (x)
-    (syntax-case x ()
-      ((_ enum-value number-value)
-       (if (< com.google.appinventor.components.common.YaVersion:BLOCKS_LANGUAGE_VERSION 33)
-           #'number-value
-           #'enum-value)))))
 ;;;; def
 
 ;;; Def here is putting things (1) in the form environment; (2) in a

--- a/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
+++ b/appinventor/buildserver/src/com/google/appinventor/buildserver/resources/runtime.scm
@@ -1672,6 +1672,10 @@
 
 (define (yail-atomic-equal? x1 x2)
   (cond
+   ;; enums must be coerced to their underlying values for backwards compatibility.
+   ((enum? x1) (yail-atomic-equal? (x1:toUnderlyingValue) x2))
+   ((enum? x2) (yail-atomic-equal? x1 (x2:toUnderlyingValue)))
+
    ;; equal? covers the case where x1 and x2 are equal objects or equal strings.
    ((equal? x1 x2) #t)
    ;; This implementation says that "0" is equal to "00" since
@@ -1684,9 +1688,6 @@
    ;; Uncomment these two lines to use string=? on strings
    ;; ((and (string? x1) (string? x2))
    ;;  (equal? x1 x2))
-
-   ((and (enum? x1) (not (enum? x2))) (equal? (x1:toUnderlyingValue) x2))
-   ((and (not (enum? x1)) (enum? x2)) (equal? x1 (x2:toUnderlyingValue)))
 
    ;; If the x1 and x2 are not equal?, try comparing coverting x1 and x2 to numbers
    ;; and comparing them numerically

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -598,7 +598,7 @@ public class YaVersion {
   // - The and/or blocks gained mutators.
   // For BLOCKS_LANGUAGE_VERSION 33
   // - The helpers_screen_names block was added.
-
+  // - Add sanitizing concrete values to OptionLists.
   public static final int BLOCKS_LANGUAGE_VERSION = 33;
 
   // ................................. Target SDK Version Number ..................................

--- a/appinventor/components/src/com/google/appinventor/components/runtime/EventDispatcher.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/EventDispatcher.java
@@ -189,6 +189,7 @@ public class EventDispatcher {
     if (DEBUG) {
       Log.i("EventDispatcher", "Trying to dispatch event " + eventName);
     }
+    args = OptionHelper.optionListsFromValues(component, eventName, args);
     boolean dispatched = false;
     HandlesEventDispatching dispatchDelegate = component.getDispatchDelegate();
     if (dispatchDelegate.canDispatchEvent(component, eventName)) {

--- a/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/Form.java
@@ -1640,7 +1640,7 @@ public class Form extends AppInventorCompatActivity
   @SimpleProperty(category = PropertyCategory.APPEARANCE,
     description = "The animation for switching to another screen. Valid" +
     " options are default, fade, zoom, slidehorizontal, slidevertical, and none"    )
-  public String OpenScreenAnimation() {
+  public @Options(ScreenAnimation.class) String OpenScreenAnimation() {
     if (openAnimType != null) {
       return openAnimType.toUnderlyingValue();
     }
@@ -1692,7 +1692,7 @@ public class Form extends AppInventorCompatActivity
     description = "The animation for closing current screen and returning " +
     " to the previous screen. Valid options are default, fade, zoom, slidehorizontal, " +
     "slidevertical, and none")
-  public String CloseScreenAnimation() {
+  public @Options(ScreenAnimation.class) String CloseScreenAnimation() {
     if (closeAnimType != null) {
       return closeAnimType.toUnderlyingValue();
     }

--- a/appinventor/components/src/com/google/appinventor/components/runtime/OptionHelper.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/OptionHelper.java
@@ -23,6 +23,10 @@ public class OptionHelper {
   public static Map<String, Map<String, Method>> componentMethods =
       new HashMap<String, Map<String, Method>>();
     
+  /**
+   * Returns the OptionList version of the value if the function's return type has an @Options
+   * annotation notating that the value can be coerced to an OptionList.
+   */
   public static <T> Object optionListFromValue(Component c, String func, T value) {
     Method calledFunc = getMethod(c, func);
     if (calledFunc == null) {
@@ -46,6 +50,10 @@ public class OptionHelper {
     }
   }
 
+  /**
+   * Returns the args after any coercable args have been coerced to an OptionList. An arg is
+   * coercable if the function header has an @Options annotation associated with that arguement.
+   */
   public static Object[] optionListsFromValues(Component c, String func, Object...args) {
     if (args.length == 0) {
       return args;
@@ -79,6 +87,10 @@ public class OptionHelper {
     return args;
   }
 
+  /**
+   * Returns the Method associated with the given component and function name. Returns null if the
+   * Method does not exist or shouldn't be operated on in this context (e.g. a void method).
+   */
   private static Method getMethod(Component c, String func) {
     Class<?> componentClass = c.getClass();
     String componentKey = componentClass.getSimpleName();
@@ -92,6 +104,10 @@ public class OptionHelper {
     return methodMap.get(func);
   }
 
+  /**
+   * Returns a map populated with all relevant Methods of the given Class. This includes all events,
+   * property getters, and non-void methods.
+   */
   private static Map<String, Method> populateMap(Class<?> clazz) {
     Map<String, Method> methodMap = new HashMap<String, Method>();
     Method[] methods = clazz.getMethods();

--- a/appinventor/components/src/com/google/appinventor/components/runtime/OptionHelper.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/OptionHelper.java
@@ -1,0 +1,91 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.runtime;
+
+import com.google.appinventor.components.annotations.Options;
+import com.google.appinventor.components.annotations.SimpleEvent;
+import com.google.appinventor.components.annotations.SimpleFunction;
+import com.google.appinventor.components.annotations.SimpleProperty;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import android.util.Log;
+
+public class OptionHelper {
+
+  public static final String TAG = "OptionHelper";
+
+  public static Map<String, Map<String, Method>> componentMethods =
+      new HashMap<String, Map<String, Method>>();
+    
+  public static <T> Object optionListFromValue(Component c, String func, T value) {
+    Method calledFunc = getMethod(c, func);
+    if (calledFunc == null) {
+      // Doesn't exist or not relevant.
+      return value;
+    }
+    Options annotation = calledFunc.getAnnotation(Options.class);
+    if (annotation == null) {
+      return value;
+    }
+    Class<?> optionListClass = annotation.value();
+    Object newValue = null;
+    try {
+      Method fromValue = optionListClass.getMethod("fromUnderlyingValue", value.getClass());
+      newValue = fromValue.invoke(optionListClass, value);
+    } finally {
+      if (newValue != null) {
+        return newValue;
+      }
+      return value;
+    }
+  }
+
+  private static Method getMethod(Component c, String func) {
+    Class<?> componentClass = c.getClass();
+    String componentKey = componentClass.getSimpleName();
+    Map<String, Method> methodMap = componentMethods.get(componentKey);
+
+    if (methodMap == null) {
+      methodMap = populateMap(componentClass);
+      componentMethods.put(componentKey, methodMap);
+    }
+
+    return methodMap.get(func);
+  }
+
+  private static Map<String, Method> populateMap(Class<?> clazz) {
+    Map<String, Method> methodMap = new HashMap<String, Method>();
+    Method[] methods = clazz.getMethods();
+
+    // Add all the relevant methods to the map.
+    for (Method m : methods) {
+      String methodKey = m.getName();
+
+      // Always add events.
+      SimpleEvent event = m.getAnnotation(SimpleEvent.class);
+      if (event != null) {
+        methodMap.put(methodKey, m);
+        continue;
+      }
+
+      // Ignore void methods and property setters.
+      if (m.getReturnType() != Void.TYPE) {
+        SimpleFunction func = m.getAnnotation(SimpleFunction.class);
+        if (func != null) {
+          methodMap.put(methodKey, m);
+          continue;
+        }
+        SimpleProperty prop = m.getAnnotation(SimpleProperty.class);
+        if (prop != null) {
+          methodMap.put(methodKey, m);
+        }
+      }
+    }
+    return methodMap;
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1746,9 +1746,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
   private HelperKey hasOptionListHelper(Element elem, TypeMirror type) {
     // Check if the elem type is an OptionList
     if (isOptionList(type)) {
-      throw new RuntimeException("Using OptionLists as parameter types is not yet supported. Please " +
-          "use a concrete value (such as int, or String) annotated with an @Options parameter.");
-      //return optionListToHelperKey(((DeclaredType)type).asElement());
+      return optionListToHelperKey(((DeclaredType)type).asElement());
     }
 
     // Check if the elem has an @Options annotation.

--- a/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
+++ b/appinventor/components/src/com/google/appinventor/components/scripts/ComponentProcessor.java
@@ -1746,7 +1746,7 @@ public abstract class ComponentProcessor extends AbstractProcessor {
   private HelperKey hasOptionListHelper(Element elem, TypeMirror type) {
     // Check if the elem type is an OptionList
     if (isOptionList(type)) {
-      return optionListToHelperKey(((DeclaredType)type).asElement());
+      return optionListToHelperKey(((DeclaredType) type).asElement());
     }
 
     // Check if the elem has an @Options annotation.


### PR DESCRIPTION
### Description

Depends on #10 

Implements all of the abstraction stuff:
* Sanitizing method and getter return values.
* Sanitizing event parameter values.
* Dropdown blocks returning different values depending on companion version.
* Allowing dropdown blocks to be dictionary keys.

Important Note: I couldn't get the protect-enum macro to work from the getFormYail() function, and I couldn't get *any* logging working. So I need some help :/

And another note: This PR is maximally backwards compatible. If you think any backwards compatibility stuff should be removed for maintainability, simplicity, etc, I am happy to remove it =)

### Testing

* Tested that methods and getters are sanitized properly depending on the version of the companion.
* Tested that event params are sanitized properly depending on the version of the companion.
* Tested that enum values can be used to access both the value and the underlying value from the dictionary.

Both this:
![blocks (2)](https://user-images.githubusercontent.com/25440652/89112176-cef74480-d413-11ea-9e21-f281be1fec6f.png)

And this:
![blocks (3)](https://user-images.githubusercontent.com/25440652/89112181-d3236200-d413-11ea-85ae-db3e75befb78.png)

return "East value"!

### Recommended Method for Review
Commit-Wise