### PR TITLE
Add screen names block

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
@@ -94,12 +94,12 @@ public class DesignToolbar extends Toolbar {
 
     // Returns true if we added the screen (it didn't previously exist), false otherwise.
     public boolean addScreen(String name, FileEditor formEditor, FileEditor blocksEditor) {
-      if (!screens.containsKey(name)) {
-        screens.put(name, new Screen(name, formEditor, blocksEditor));
-        return true;
-      } else {
+      if (screens.containsKey(name)) {
         return false;
       }
+      screens.put(name, new Screen(name, formEditor, blocksEditor));
+      ((YaBlocksEditor) blocksEditor).addScreen(name);
+      return true;
     }
 
     public void removeScreen(String name) {

--- a/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
@@ -98,15 +98,11 @@ public class DesignToolbar extends Toolbar {
         return false;
       }
       screens.put(name, new Screen(name, formEditor, blocksEditor));
-      ((YaBlocksEditor) blocksEditor).addScreen(name);
       return true;
     }
 
     public void removeScreen(String name) {
-      if (screens.containsKey(name)) {
-        Screen screen = screens.remove(name);
-        ((YaBlocksEditor) screen.blocksEditor).removeScreen(name);
-      }
+      screens.remove(name);
     }
 
     public void setCurrentScreen(String name) {
@@ -408,16 +404,8 @@ public class DesignToolbar extends Toolbar {
         OdeLog.wlog("DesignToolbar: ignoring call to switchToProject for current project");
         return true;
       }
-
-      // Clear screens.
       pushedScreens.clear();  // Effectively switching applications; clear stack of screens.
       clearDropDownMenu(WIDGET_NAME_SCREENS_DROPDOWN);
-      if (currentProject != null) {
-        for (Screen s : currentProject.screens.values()) {
-          ((YaBlocksEditor) s.blocksEditor).removeScreen(s.screenName);
-        }
-      }
-
       OdeLog.log("DesignToolbar: switching to existing project " + projectName + " with id "
           + projectId);
       currentProject = project;

--- a/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
@@ -103,7 +103,10 @@ public class DesignToolbar extends Toolbar {
     }
 
     public void removeScreen(String name) {
-      screens.remove(name);
+      if (screens.containsKey(name)) {
+        Screen screen = screens.remove(name);
+        ((YaBlocksEditor) screen.blocksEditor).removeScreen(name);
+      }
     }
 
     public void setCurrentScreen(String name) {

--- a/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/DesignToolbar.java
@@ -408,11 +408,20 @@ public class DesignToolbar extends Toolbar {
         OdeLog.wlog("DesignToolbar: ignoring call to switchToProject for current project");
         return true;
       }
-      pushedScreens.clear();    // Effectively switching applications clear stack of screens
+
+      // Clear screens.
+      pushedScreens.clear();  // Effectively switching applications; clear stack of screens.
       clearDropDownMenu(WIDGET_NAME_SCREENS_DROPDOWN);
+      if (currentProject != null) {
+        for (Screen s : currentProject.screens.values()) {
+          ((YaBlocksEditor) s.blocksEditor).removeScreen(s.screenName);
+        }
+      }
+
       OdeLog.log("DesignToolbar: switching to existing project " + projectName + " with id "
           + projectId);
-      currentProject = projectMap.get(projectId);
+      currentProject = project;
+
       // TODO(sharon): add screens to drop-down menu in the right order
       for (Screen screen : currentProject.screens.values()) {
         addDropDownButtonItem(WIDGET_NAME_SCREENS_DROPDOWN, new DropDownItem(screen.screenName,

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -703,6 +703,11 @@ public class BlocklyPanel extends HTMLPanel {
       .saveBlocksFile();
   }-*/;
 
+  public native void addScreen(String name)/*-{
+    this.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace
+      .addScreen(name);
+  }-*/;
+
   /**
    * Add a component to the blocks workspace
    *

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/BlocklyPanel.java
@@ -708,6 +708,11 @@ public class BlocklyPanel extends HTMLPanel {
       .addScreen(name);
   }-*/;
 
+  public native void removeScreen(String name)/*-{
+    this.@com.google.appinventor.client.editor.youngandroid.BlocklyPanel::workspace
+      .removeScreen(name);
+  }-*/;
+
   /**
    * Add a component to the blocks workspace
    *

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -429,6 +429,10 @@ public final class YaBlocksEditor extends FileEditor
     blocksArea.addScreen(name);
   }
 
+  public void removeScreen(String name) {
+    blocksArea.removeScreen(name);
+  }
+
   public static String getComponentInfo(String typeName) {
     return SimpleComponentDatabase.getInstance().getTypeDescription(typeName);
   }

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -114,8 +114,11 @@ public final class YaBlocksEditor extends FileEditor
   // blocks area again.
   private Set<String> componentUuids = new HashSet<String>();
 
-  // The form editor associated with this blocks editor
+  // The form editor associated with this blocks editor.
   private YaFormEditor myFormEditor;
+
+  // The project associated with this blocks editor.
+  private Project project;
 
   YaBlocksEditor(YaProjectEditor projectEditor, YoungAndroidBlocksNode blocksNode) {
     super(projectEditor, blocksNode);
@@ -165,7 +168,7 @@ public final class YaBlocksEditor extends FileEditor
       OdeLog.wlog("Can't get form editor for blocks: " + getFileId());
     }
 
-    Project project = Ode.getInstance().getProjectManager().getProject(blocksNode.getProjectId());
+    project = Ode.getInstance().getProjectManager().getProject(blocksNode.getProjectId());
     project.addProjectChangeListener(this);
     onProjectLoaded(project);
   }
@@ -278,8 +281,10 @@ public final class YaBlocksEditor extends FileEditor
   public void onClose() {
     // our partner YaFormEditor added us as a FormChangeListener, but we remove ourself.
     getForm().removeFormChangeListener(this);
+    project.removeProjectChangeListener(this);
     BlockSelectorBox.getBlockSelectorBox().removeBlockDrawerSelectionListener(this);
     formToBlocksEditor.remove(fullFormName);
+
   }
 
   public static void toggleWarning() {

--- a/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/editor/youngandroid/YaBlocksEditor.java
@@ -425,6 +425,10 @@ public final class YaBlocksEditor extends FileEditor
     // Nothing to do after blocks are saved.
   }
 
+  public void addScreen(String name) {
+    blocksArea.addScreen(name);
+  }
+
   public static String getComponentInfo(String typeName) {
     return SimpleComponentDatabase.getInstance().getTypeDescription(typeName);
   }

--- a/appinventor/blocklyeditor/src/blocklyeditor.js
+++ b/appinventor/blocklyeditor/src/blocklyeditor.js
@@ -392,6 +392,7 @@ Blockly.BlocklyEditor['create'] = function(container, formName, readOnly, rtl) {
   Blockly.allWorkspaces[formName] = workspace;
   workspace.formName = formName;
   workspace.rendered = false;
+  workspace.screenList_ = [];
   workspace.componentDb_ = new Blockly.ComponentDatabase();
   workspace.procedureDb_ = new Blockly.ProcedureDatabase(workspace);
   workspace.variableDb_ = new Blockly.VariableDatabase();

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -142,9 +142,7 @@ Blockly.Blocks['helpers_screen_names'] = {
   },
 
   getScreens: function() {
-    var screens = Blockly.mainWorkspace.getScreenList();
-    screens.splice(screens.indexOf('Screen1'), 1);
-    return screens;
+    return Blockly.mainWorkspace.getScreenList();
   },
 
   generateOptions: function() {
@@ -163,7 +161,7 @@ Blockly.Blocks['helpers_screen_names'] = {
   typeblock: function() {
     var tb = [];
 
-    var screens = this.getScreens();
+    var screens = Blockly.mainWorkspace.getScreenList();
     for (var i = 0, screen; (screen = screens[i]); i++) {
       tb.push({
         translatedName: Blockly.Msg.LANG_SCREENS_TITLE + screen,

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -142,6 +142,9 @@ Blockly.Blocks['helpers_screen_names'] = {
   },
 
   generateOptions: function() {
+    if (!this.workspace) {
+      return [['', '']];
+    }
     var screens = this.workspace.getScreenList();
     return screens.map(function (elem) {
       return [elem, elem];

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -146,5 +146,21 @@ Blockly.Blocks['helpers_screen_names'] = {
     return screens.map(function (elem) {
       return [elem, elem];
     });
+  },
+
+  typeblock: function() {
+    var tb = [];
+
+    var screens = Blockly.mainWorkspace.getScreenList();
+    for (var i = 0, screen; (screen = screens[i]); i++) {
+      tb.push({
+        translatedName: Blockly.Msg.LANG_SCREENS_TITLE + screen,
+        mutatorAttributes: {
+          value: screen
+        }
+      })
+    }
+
+    return tb;
   }
 }

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -122,3 +122,29 @@ Blockly.Blocks['helpers_dropdown'] = {
     return tb;
   }
 }
+
+Blockly.Blocks['helpers_screen_names'] = {
+  init: function() {
+    var utils = Blockly.Blocks.Utilities;
+    var dropdown = new Blockly.FieldInvalidDropdown(
+        this.generateOptions.bind(this));
+
+    this.setColour(Blockly.COLOUR_HELPERS);
+
+    this.setOutput(true, utils.YailTypeToBlocklyType('text', utils.OUTPUT));
+    this.appendDummyInput()
+        .appendField(dropdown, 'SCREEN');
+  },
+
+  domToMutation: function(xml) {
+    var value = xml.getAttribute('value');
+    this.setFieldValue(value, 'SCREEN');
+  },
+
+  generateOptions: function() {
+    var screens = this.workspace.getScreenList();
+    return screens.map(function (elem) {
+      return [elem, elem];
+    });
+  }
+}

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -142,16 +142,15 @@ Blockly.Blocks['helpers_screen_names'] = {
   },
 
   getScreens: function() {
-    if (!this.workspace) {
-      return [];
-    }
     var screens = Blockly.mainWorkspace.getScreenList();
     screens.splice(screens.indexOf('Screen1'), 1);
-    console.log(screens);
     return screens;
   },
 
   generateOptions: function() {
+    if (!this.workspace) {
+      return [['', '']]
+    }
     var screens = this.getScreens();
     if (!screens.length) {
       return [['', '']]

--- a/appinventor/blocklyeditor/src/blocks/helpers.js
+++ b/appinventor/blocklyeditor/src/blocks/helpers.js
@@ -141,11 +141,21 @@ Blockly.Blocks['helpers_screen_names'] = {
     this.setFieldValue(value, 'SCREEN');
   },
 
-  generateOptions: function() {
+  getScreens: function() {
     if (!this.workspace) {
-      return [['', '']];
+      return [];
     }
-    var screens = this.workspace.getScreenList();
+    var screens = Blockly.mainWorkspace.getScreenList();
+    screens.splice(screens.indexOf('Screen1'), 1);
+    console.log(screens);
+    return screens;
+  },
+
+  generateOptions: function() {
+    var screens = this.getScreens();
+    if (!screens.length) {
+      return [['', '']]
+    }
     return screens.map(function (elem) {
       return [elem, elem];
     });
@@ -154,7 +164,7 @@ Blockly.Blocks['helpers_screen_names'] = {
   typeblock: function() {
     var tb = [];
 
-    var screens = Blockly.mainWorkspace.getScreenList();
+    var screens = this.getScreens();
     for (var i = 0, screen; (screen = screens[i]); i++) {
       tb.push({
         translatedName: Blockly.Msg.LANG_SCREENS_TITLE + screen,

--- a/appinventor/blocklyeditor/src/drawer.js
+++ b/appinventor/blocklyeditor/src/drawer.js
@@ -659,6 +659,24 @@ Blockly.Drawer.defaultBlockXMLStrings = {
     '</block>' +
   '</xml>' },
 
+  controls_openAnotherScreen: {xmlString:
+  '<xml>' +
+    '<block type="controls_openAnotherScreen">' +
+      '<value name="SCREEN">' +
+        '<block type="helpers_screen_names"></block>' +
+      '</value>' +
+    '</block>' +
+  '</xml>' },
+
+  controls_openAnotherScreenWithStartValue: {xmlString:
+  '<xml>' +
+    '<block type="controls_openAnotherScreenWithStartValue">' +
+      '<value name="SCREENNAME">' +
+        '<block type="helpers_screen_names"></block>' +
+      '</value>' +
+    '</block>' +
+  '</xml>' },
+
    math_random_int: {xmlString:
   '<xml>' +
     '<block type="math_random_int">' +

--- a/appinventor/blocklyeditor/src/generators/yail/helpers.js
+++ b/appinventor/blocklyeditor/src/generators/yail/helpers.js
@@ -29,3 +29,8 @@ Blockly.Yail['helpers_dropdown'] = function() {
   // it does it will return the abstract enum value. If the companion does not
   // support OptionLists it will continue to return the concrete value.
 }
+
+Blockly.Yail['helpers_screen_names'] = function() {
+  var value = Blockly.Yail.quote_(this.getFieldValue('SCREEN'));
+  return [value, Blockly.Yail.ORDER_ATOMIC];
+}

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -1548,6 +1548,9 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_COMPONENT_BLOCK_VOTING_EVENTS_HELPURL = '/reference/components/internal.html#votingevents';
     Blockly.Msg.LANG_COMPONENT_BLOCK_VOTING_METHODS_HELPURL = '/reference/components/internal.html#votingmethods';
 
+// Helper Blocks
+    Blockly.Msg.LANG_SCREENS_TITLE = "Screen Name: ";
+
 //Misc
     Blockly.Msg.SHOW_WARNINGS = "Show Warnings";
     Blockly.Msg.HIDE_WARNINGS = "Hide Warnings";

--- a/appinventor/blocklyeditor/src/msg/en/_messages.js
+++ b/appinventor/blocklyeditor/src/msg/en/_messages.js
@@ -279,7 +279,8 @@ Blockly.Msg.en.switch_language_to_english = {
     Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_TITLE = 'open another screen';
     Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_INPUT_SCREENNAME = 'screenName';
     Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_COLLAPSED_TEXT = 'open screen';
-    Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_TOOLTIP = 'Opens a new screen in a multiple screen app.';
+    Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_TOOLTIP = 'Opens a new screen in a multiple screen app. '
+        + 'You should not use this block to return to Screen1. Use the close screen block instead.';
 
     Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_HELPURL = '/reference/blocks/control.html#openscreenwithvalue';
     Blockly.Msg.LANG_CONTROLS_OPEN_ANOTHER_SCREEN_WITH_START_VALUE_TITLE = 'open another screen with start value';

--- a/appinventor/blocklyeditor/src/typeblock.js
+++ b/appinventor/blocklyeditor/src/typeblock.js
@@ -41,10 +41,14 @@ Blockly.TypeBlock = function( htmlConfig, workspace ){
    * Used as an optimisation trick to avoid reloading components and built-ins unless there is a real
    * need to do so. needsReload.components can be set to true when a component changes.
    * Defaults to true so that it loads the first time (set to null after loading in lazyLoadOfOptions_())
-   * @type {{components: boolean}}
+   * @type {{
+   *         components: boolean,
+   *         screens: boolean
+   *       }}
    */
   this.needsReload = {
-    components: true
+    components: true,
+    screens: true,
   };
   var frame = htmlConfig['frame'];
   this.typeBlockDiv_ = htmlConfig['typeBlockDiv'];
@@ -252,12 +256,12 @@ Blockly.TypeBlock.prototype.show = function(){
  * @private
  */
 Blockly.TypeBlock.prototype.lazyLoadOfOptions_ = function () {
-
   // Optimisation to avoid reloading all components and built-in objects unless it is needed.
   // needsReload.components is setup when adding/renaming/removing a component in components.js
-  if (this.needsReload.components){
+  if (this.needsReload.components || this.needsReload.screens){
     this.generateOptions();
-    this.needsReload.components = null;
+    this.needsReload.components = false;
+    this.needsReload.screens = false;
   }
   this.loadGlobalVariables_();
   this.loadLocalVariables_();

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -744,6 +744,28 @@ Blockly.Versioning.v17_translateComponentSetGetProperty = function(blockElem) {
 };
 
 /******************************************************************************
+ Upgrade screen names to use dropdown block.
+ ******************************************************************************/
+
+Blockly.Versioning.makeScreenNamesBeDropdowns = function () {
+  return function(blocksRep, workspace) {
+    var dom = Blockly.Versioning.ensureDom(blocksRep);
+    for (var i = 0, block; block = dom.children[i]; i++) {
+      if (block.tagName == 'block' &&
+          (block.getAttribute('type') == 'controls_openAnotherScreen' ||
+          block.getAttribute('type') == 'controls_openAnotherScreenWithStartValue')) {
+        var value = Blockly.Versioning.firstChildWithTagName(block, 'value');
+        var name = value.getAttribute('name');
+        if (name == 'SCREENNAME' || name == 'SCREEN') {
+          Blockly.Versioning.tryReplaceBlockWithScreen(value);
+        }
+      }
+    }
+    return blocksRep;
+  }
+};
+
+/******************************************************************************
  General helper methods for upgrades go in this section
  ******************************************************************************/
 
@@ -1076,6 +1098,36 @@ Blockly.Versioning.tryReplaceTargetBlock =
     newBlock.appendChild(field);
     valueNode.appendChild(newBlock);
   }
+
+Blockly.Versioning.tryReplaceBlockWithScreen = function(valueNode) {
+  if (!valueNode) {
+    return;
+  }
+
+  // The node describing the value input's target block.
+  var targetNode = Blockly.Versioning
+      .firstChildWithTagName(valueNode, 'block');
+  if (!targetNode) {
+    return;
+  }
+
+  var name = targetNode.getAttribute('type');
+  if (name != 'text') {
+    return;
+  }
+  var field = Blockly.Versioning.firstChildWithTagName(targetNode, 'field');
+  var targetValue = field.textContent;
+
+  valueNode.removeChild(targetNode);
+  var newBlock = document.createElement('block');
+  newBlock.setAttribute('type', 'helpers_screen_names');
+  var field = document.createElement('field');
+  field.setAttribute('name', 'SCREEN');
+  var option = document.createTextNode(targetValue);
+  field.appendChild(option);
+  newBlock.appendChild(field);
+  valueNode.appendChild(newBlock);
+}
 
 /**
  * Returns the list of top-level blocks that are event handlers for the given eventName for
@@ -1966,7 +2018,10 @@ Blockly.Versioning.AllUpgradeMaps =
     31: "noUpgrade",
 
     // AI2: Added mutators for and/or blocks
-    32: "noUpgrade"
+    32: "noUpgrade",
+
+    // AI2: Add screen names dropdown block.
+    33: Blockly.Versioning.makeScreenNamesBeDropdowns(),
 
   }, // End Language upgraders
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -749,10 +749,10 @@ Blockly.Versioning.v17_translateComponentSetGetProperty = function(blockElem) {
 
 Blockly.Versioning.makeScreenNamesBeDropdowns = function (blocksRep, workspace) {
   var dom = Blockly.Versioning.ensureDom(blocksRep);
-  for (var i = 0, block; block = dom.children[i]; i++) {
-    if (block.tagName == 'block' &&
-        (block.getAttribute('type') == 'controls_openAnotherScreen' ||
-        block.getAttribute('type') == 'controls_openAnotherScreenWithStartValue')) {
+  var allBlocks = dom.getElementsByTagName('block');
+  for (var i = 0, block; block = allBlocks[i]; i++) {
+    if (block.getAttribute('type') == 'controls_openAnotherScreen' ||
+        block.getAttribute('type') == 'controls_openAnotherScreenWithStartValue') {
       var value = Blockly.Versioning.firstChildWithTagName(block, 'value');
       var name = value.getAttribute('name');
       if (name == 'SCREENNAME' || name == 'SCREEN') {

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -1097,6 +1097,12 @@ Blockly.Versioning.tryReplaceTargetBlock =
     valueNode.appendChild(newBlock);
   }
 
+/**
+ * Replaces the block currently attached to the passed value input with a screen
+ * names block. The current block is replaced iff it is a constant (eg a text or
+ * number block). 
+ * @param {Element} valueNode The node to modify.
+ */
 Blockly.Versioning.tryReplaceBlockWithScreen = function(valueNode) {
   if (!valueNode) {
     return;

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -747,22 +747,20 @@ Blockly.Versioning.v17_translateComponentSetGetProperty = function(blockElem) {
  Upgrade screen names to use dropdown block.
  ******************************************************************************/
 
-Blockly.Versioning.makeScreenNamesBeDropdowns = function () {
-  return function(blocksRep, workspace) {
-    var dom = Blockly.Versioning.ensureDom(blocksRep);
-    for (var i = 0, block; block = dom.children[i]; i++) {
-      if (block.tagName == 'block' &&
-          (block.getAttribute('type') == 'controls_openAnotherScreen' ||
-          block.getAttribute('type') == 'controls_openAnotherScreenWithStartValue')) {
-        var value = Blockly.Versioning.firstChildWithTagName(block, 'value');
-        var name = value.getAttribute('name');
-        if (name == 'SCREENNAME' || name == 'SCREEN') {
-          Blockly.Versioning.tryReplaceBlockWithScreen(value);
-        }
+Blockly.Versioning.makeScreenNamesBeDropdowns = function (blocksRep, workspace) {
+  var dom = Blockly.Versioning.ensureDom(blocksRep);
+  for (var i = 0, block; block = dom.children[i]; i++) {
+    if (block.tagName == 'block' &&
+        (block.getAttribute('type') == 'controls_openAnotherScreen' ||
+        block.getAttribute('type') == 'controls_openAnotherScreenWithStartValue')) {
+      var value = Blockly.Versioning.firstChildWithTagName(block, 'value');
+      var name = value.getAttribute('name');
+      if (name == 'SCREENNAME' || name == 'SCREEN') {
+        Blockly.Versioning.tryReplaceBlockWithScreen(value);
       }
     }
-    return blocksRep;
   }
+  return blocksRep;
 };
 
 /******************************************************************************
@@ -2021,7 +2019,7 @@ Blockly.Versioning.AllUpgradeMaps =
     32: "noUpgrade",
 
     // AI2: Add screen names dropdown block.
-    33: Blockly.Versioning.makeScreenNamesBeDropdowns(),
+    33: Blockly.Versioning.makeScreenNamesBeDropdowns,
 
   }, // End Language upgraders
 

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -380,7 +380,7 @@ Blockly.WorkspaceSvg.prototype.getProcedureDatabase = function() {
  * @param {string} name The name of the new screen.
  */
 Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
-  if (!this.screenList_.includes(name)) {
+  if (this.screenList_.indexOf(name) == -1) {
     this.screenList_.push(name);
     this.typeBlock_.needsReload.screens = true;
   }
@@ -392,7 +392,7 @@ Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
  * @param {string} name The name of the screen to remove.
  */
 Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
-  if (this.screenList_.includes(name)) {
+  if (this.screenList_.indexOf(name) != -1) {
     this.screenList_.splice(this.screenList_.indexOf(name), 1);
     this.typeBlock_.needsReload.screens = true;
   }

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -388,6 +388,7 @@ Blockly.WorkspaceSvg.prototype.getProcedureDatabase = function() {
  */
 Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
   this.screenList_.push(name);
+  this.typeBlock_.needsReload.screens = true;
 };
 
 //noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java
@@ -397,6 +398,7 @@ Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
  */
 Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
   this.screenList_.splice(this.screenList_.indexOf(name), 1);
+  this.typeBlock_.needsReload.screens = true;
 }
 
 /**

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -404,7 +404,7 @@ Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
  * @return {!Array<string>} The list of screen names.
  */
 Blockly.WorkspaceSvg.prototype.getScreenList = function() {
-  return this.screenList_.slice();  // Return a clone.
+  return this.screenList_;
 };
 
 //noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -392,8 +392,9 @@ Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
  * @param {string} name The name of the screen to remove.
  */
 Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
-  if (this.screenList_.indexOf(name) != -1) {
-    this.screenList_.splice(this.screenList_.indexOf(name), 1);
+  var index = this.screenList_.indexOf(name);
+  if (index != -1) {
+    this.screenList_.splice(index, 1);
     this.typeBlock_.needsReload.screens = true;
   }
 }

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -406,7 +406,7 @@ Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
  * @return {!Array<string>} The list of screen names.
  */
 Blockly.WorkspaceSvg.prototype.getScreenList = function() {
-  return this.screenList_;
+  return this.screenList_.slice();  // Return a clone.
 };
 
 //noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -381,6 +381,12 @@ Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
   this.screenList_.push(name);
 };
 
+//noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java
+Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
+  console.log('removing', name, 'at index', this.screenList_.indexOf(name))
+  this.screenList_.splice(this.screenList_.indexOf(name), 1);
+}
+
 Blockly.WorkspaceSvg.prototype.getScreenList = function() {
   return this.screenList_;
 };

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -36,6 +36,11 @@ Blockly.WorkspaceSvg.prototype.backpack_ = null;
  */
 Blockly.WorkspaceSvg.prototype.componentDb_ = null;
 
+/**
+ * The list of screen names currently in this project.
+ * @type {!Array<string>}
+ * @private
+ */
 Blockly.WorkspaceSvg.prototype.screenList_ = [];
 
 /**
@@ -377,16 +382,27 @@ Blockly.WorkspaceSvg.prototype.getProcedureDatabase = function() {
 };
 
 //noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java
+/**
+ * Adds a screen name to the list tracked by the workspace.
+ * @param {string} name The name of the new screen.
+ */
 Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
   this.screenList_.push(name);
 };
 
 //noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java
+/**
+ * Removes a screen name from the list tracked by the workspace.
+ * @param {string} name The name of the screen to remove.
+ */
 Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
-  console.log('removing', name, 'at index', this.screenList_.indexOf(name))
   this.screenList_.splice(this.screenList_.indexOf(name), 1);
 }
 
+/**
+ * Returns the list of screen names tracked by the workspace.
+ * @return {!Array<string>} The list of screen names.
+ */
 Blockly.WorkspaceSvg.prototype.getScreenList = function() {
   return this.screenList_;
 };

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -36,6 +36,8 @@ Blockly.WorkspaceSvg.prototype.backpack_ = null;
  */
 Blockly.WorkspaceSvg.prototype.componentDb_ = null;
 
+Blockly.WorkspaceSvg.prototype.screenList_ = [];
+
 /**
  * The workspace's typeblock instance.
  * @type {Blockly.TypeBlock}
@@ -372,6 +374,15 @@ Blockly.WorkspaceSvg.prototype.getComponentDatabase = function() {
  */
 Blockly.WorkspaceSvg.prototype.getProcedureDatabase = function() {
   return this.procedureDb_;
+};
+
+//noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java
+Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
+  this.screenList_.push(name);
+};
+
+Blockly.WorkspaceSvg.prototype.getScreenList = function() {
+  return this.screenList_;
 };
 
 //noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java

--- a/appinventor/blocklyeditor/src/workspace_svg.js
+++ b/appinventor/blocklyeditor/src/workspace_svg.js
@@ -37,13 +37,6 @@ Blockly.WorkspaceSvg.prototype.backpack_ = null;
 Blockly.WorkspaceSvg.prototype.componentDb_ = null;
 
 /**
- * The list of screen names currently in this project.
- * @type {!Array<string>}
- * @private
- */
-Blockly.WorkspaceSvg.prototype.screenList_ = [];
-
-/**
  * The workspace's typeblock instance.
  * @type {Blockly.TypeBlock}
  * @private
@@ -387,8 +380,10 @@ Blockly.WorkspaceSvg.prototype.getProcedureDatabase = function() {
  * @param {string} name The name of the new screen.
  */
 Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
-  this.screenList_.push(name);
-  this.typeBlock_.needsReload.screens = true;
+  if (!this.screenList_.includes(name)) {
+    this.screenList_.push(name);
+    this.typeBlock_.needsReload.screens = true;
+  }
 };
 
 //noinspection JSUnusedGlobalSymbols Called from BlocklyPanel.java
@@ -397,8 +392,10 @@ Blockly.WorkspaceSvg.prototype.addScreen = function(name) {
  * @param {string} name The name of the screen to remove.
  */
 Blockly.WorkspaceSvg.prototype.removeScreen = function(name) {
-  this.screenList_.splice(this.screenList_.indexOf(name), 1);
-  this.typeBlock_.needsReload.screens = true;
+  if (this.screenList_.includes(name)) {
+    this.screenList_.splice(this.screenList_.indexOf(name), 1);
+    this.typeBlock_.needsReload.screens = true;
+  }
 }
 
 /**

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -596,8 +596,10 @@ public class YaVersion {
   // - The replace-all-mappings block was added.
   // For BLOCKS_LANGUAGE_VERSION 32
   // - The and/or blocks gained mutators.
+  // For BLOCKS_LANGUAGE_VERSION 33
+  // - The helpers_screen_names block was added.
 
-  public static final int BLOCKS_LANGUAGE_VERSION = 32;
+  public static final int BLOCKS_LANGUAGE_VERSION = 33;
 
   // ................................. Target SDK Version Number ..................................
 

--- a/appinventor/docs/html/reference/blocks/control.html
+++ b/appinventor/docs/html/reference/blocks/control.html
@@ -203,7 +203,8 @@
 
 <p>Opens the screen with the provided name.</p>
 
-<p>The screenName must be one of the Screens created using the Designer. The screenName should be entered into a Text component and typed exactly as named in the Designer. (Case is important, if the designed screen name is myNewScreen, what you use in the puzzle piece cannot be mynewscreen or MyNewScreen for example.)</p>
+<p>The screenName must be one of the Screens created using the Designer. The
+screenName should be selected from the connected screen name dropdown block.</p>
 
 <p>If you do open another screen, you should close it when returning to your main screen to free system memory. Failure to close a screen upon leaving it will eventually lead to memory problems.</p>
 

--- a/appinventor/docs/markdown/reference/blocks/control.md
+++ b/appinventor/docs/markdown/reference/blocks/control.md
@@ -82,7 +82,8 @@ Provides a "dummy socket" for fitting a block that has a plug on its left into a
 
 Opens the screen with the provided name.
 
-The screenName must be one of the Screens created using the Designer. The screenName should be entered into a Text component and typed exactly as named in the Designer. (Case is important, if the designed screen name is myNewScreen, what you use in the puzzle piece cannot be mynewscreen or MyNewScreen for example.)
+The screenName must be one of the Screens created using the Designer. The
+screenName should be selected from the connected screen name dropdown block.
 
 If you do open another screen, you should close it when returning to your main screen to free system memory. Failure to close a screen upon leaving it will eventually lead to memory problems.
 


### PR DESCRIPTION
### Description

Depends on #10

Adds a screen names block that can be passed to blocks like:
![blocks (2)](https://user-images.githubusercontent.com/25440652/85959540-e8f3c200-b951-11ea-8d16-f5d38d6e7dec.png)

which require a screen name.

**Important Note**: Currently this does not include any upgraders because it's not in the right branch path. They can always be added later.

### Testing

1. Created Screen1 and Screen2.
2. Added the following blocks to Screen1:
    <img width="381" alt="blocks" src="https://user-images.githubusercontent.com/25440652/85959519-c5307c00-b951-11ea-83ea-249b6d693739.png">
3. Connected to the companion and observed that the app correctly switched to Screen2.
4. Removed Screen2.
5. Observed that the block was marked as a bad block:
    <img width="381" alt="blocks (1)" src="https://user-images.githubusercontent.com/25440652/85959520-c8c40300-b951-11ea-80da-44eaab055e3e.png">
6. Added Screen2 again.
7. Observed that the block was no longer marked as a bad block.
8. Removed Screen2 again.
9. Selected Screen1 in dropdown.
10. Observed that the block was no longer marked as a bad block.