### PR TITLE
Add YandexLangs

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1803,6 +1803,10 @@ public final class YoungAndroidFormUpgrader {
       // The ApiKey property was added
       srcCompVersion = 2;
     }
+    if (srcCompVersion < 3) {
+      // Add YandexLang dropdown block.
+      srcCompVersion = 3;
+    }
     return srcCompVersion;
   }
 

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2872,7 +2872,11 @@ Blockly.Versioning.AllUpgradeMaps =
     1: "noUpgrade",
 
     // AI2: ApiKey property added
-    2: "noUpgrade"
+    2: "noUpgrade",
+
+    // Add YandexLang dropdown block.
+    3: Blockly.Versioning.makeMethodUseDropdown(
+        'YandexTranslate', 'RequestTranslation', 0, 'YandexLang')
 
   } // End YandexTranslate upgraders
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1360,7 +1360,9 @@ public class YaVersion {
   // - Initial version.
   // For YANDEX_COMPONENT_VERSION 2:
   // - Added ApiKey property
-  public static final int YANDEX_COMPONENT_VERSION = 2;
+  // For YANDEX_COMPONENT_VERSION 3:
+  // - Add YandexLang dropdown block.
+  public static final int YANDEX_COMPONENT_VERSION = 3;
 
   //For PROXIMITYSENSOR_COMPONENT_VERSION: Initial Version
   public static final int PROXIMITYSENSOR_COMPONENT_VERSION = 1;

--- a/appinventor/components/src/com/google/appinventor/components/common/YandexLang.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YandexLang.java
@@ -1,0 +1,131 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.components.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines a YandexLang type used by the YandexTranslate component. The values
+ * are ISO 639-1 (sometimes 639-2) codes.
+ */
+public enum YandexLang implements OptionList<String> {
+  Afrikaans("af"),
+  Albanian("sq"),
+  Amharic("am"),
+  Arabic("ar"),
+  Armenian("hy"),
+  Azerbaijani("az"),
+  Bashkir("ba"),
+  Basque("eu"),
+  Belarusian("be"),
+  Bengali("bn"),
+  Bosnian("bs"),
+  Bulgarian("bg"),
+  Burmese("my"),
+  Catalan("ca"),
+  Cebuano("ceb"), // Only ISO 639-2
+  Chinese("zh"),
+  Chuvash("cv"),
+  Croatian("hr"),
+  Czech("cs"),
+  Danish("da"),
+  Dutch("nl"),
+  English("en"),
+  Esperanto("eo"),
+  Estonian("et"),
+  Farsi("fa"),
+  Finnish("fi"),
+  French("fr"),
+  Galician("gl"),
+  Georgian("ka"),
+  German("de"),
+  Greek("el"),
+  Gujarati("gu"),
+  Haitian("ht"),
+  Hebrew("he"),
+  HillMari("mrj"), // Only ISO 639-2
+  Hindi("hi"),
+  Hungarian("hu"),
+  Icelandic("is"),
+  Indonesian("id"),
+  Irish("ga"),
+  Italian("it"),
+  Japanese("ja"),
+  Javanese("jv"),
+  Kannada("kn"),
+  Kazakh("kk"),
+  Khmer("km"),
+  Korean("ko"),
+  Kyrgyz("ky"),
+  Lao("lo"),
+  Latin("la"),
+  Latvian("lv"),
+  Lithuanian("lt"),
+  Luxembourgish("lb"),
+  Macedonian("mk"),
+  Malagasy("mg"),
+  Malay("ms"),
+  Malayalam("ml"),
+  Maltese("mt"),
+  Maori("mi"),
+  Marathi("mr"),
+  Mongolian("mn"),
+  Nepali("ne"),
+  Norwegian("no"),
+  Papiamento("pap"), // Only ISO 639-2
+  Polish("pl"),
+  Portuguese("pt"),
+  Punjabi("pa"),
+  Romanian("ro"),
+  Russian("ru"),
+  ScottishGaelic("gd"),
+  Serbian("sr"),
+  Sinhalese("si"),
+  Slovak("sk"),
+  Slovenian("sl"),
+  Spanish("es"),
+  Sundanese("su"),
+  Swahili("sw"),
+  Swedish("sv"),
+  Tagalog("tl"),
+  Tajik("tg"),
+  Tamil("ta"),
+  Tatar("tt"),
+  Telugu("te"),
+  Thai("th"),
+  Turkish("tr"),
+  Udmurt("udm"), // Only ISO 639-2
+  Ukrainian("uk"),
+  Urdu("ur"),
+  Uzbek("uz"),
+  Vietnamese("vi"),
+  Welsh("cy"),
+  Xhosa("xh"),
+  Yiddish("yi");
+
+  private String value;
+
+  YandexLang(String langCode) {
+    this.value = langCode;
+  }
+
+  public String toUnderlyingValue() {
+    return value;
+  }
+
+  private static final Map<String, YandexLang> lookup = new HashMap<>();
+
+  static {
+    for(YandexLang langCode : YandexLang.values()) {
+      lookup.put(langCode.toUnderlyingValue(), langCode);
+    }
+  }
+
+  public static YandexLang fromUnderlyingValue(String langCode) {
+    return lookup.get(langCode);
+  }
+}

--- a/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
@@ -146,8 +146,7 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
    */
   public void RequestTranslationAbstract(
     YandexLang languageToTranslateTo,
-    String textToTranslate
-  ) {
+    String textToTranslate) {
     // Usually when we are upgrading components to use dropdown blocks we make the Abstract function
     // the "true" function. But in this case I think it makes more sense to use the concret one.
     RequestTranslation(languageToTranslateTo.toUnderlyingValue(), textToTranslate);

--- a/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
+++ b/appinventor/components/src/com/google/appinventor/components/runtime/YandexTranslate.java
@@ -12,6 +12,7 @@ import android.text.TextUtils;
 
 import com.google.appinventor.components.annotations.DesignerComponent;
 import com.google.appinventor.components.annotations.DesignerProperty;
+import com.google.appinventor.components.annotations.Options;
 import com.google.appinventor.components.annotations.SimpleEvent;
 import com.google.appinventor.components.annotations.SimpleFunction;
 import com.google.appinventor.components.annotations.SimpleObject;
@@ -20,6 +21,7 @@ import com.google.appinventor.components.annotations.UsesPermissions;
 
 import com.google.appinventor.components.common.ComponentCategory;
 import com.google.appinventor.components.common.PropertyTypeConstants;
+import com.google.appinventor.components.common.YandexLang;
 import com.google.appinventor.components.common.YaVersion;
 
 import com.google.appinventor.components.runtime.util.AsynchUtil;
@@ -113,7 +115,7 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
       "executed.\nNote: Yandex.Translate will attempt to detect the source language. You can " +
       "also specify prepending it to the language translation. I.e., es-ru will specify Spanish " +
       "to Russian translation.")
-  public void RequestTranslation(final String languageToTranslateTo,
+  public void RequestTranslation(@Options(YandexLang.class) final String languageToTranslateTo,
                                  final String textToTranslate) {
 
     if (TextUtils.isEmpty(yandexKey) &&
@@ -137,6 +139,18 @@ public final class YandexTranslate extends AndroidNonvisibleComponent {
         }
       }
     });
+  }
+
+  /**
+   * Sends a request to translate the given text to the given language.
+   */
+  public void RequestTranslationAbstract(
+    YandexLang languageToTranslateTo,
+    String textToTranslate
+  ) {
+    // Usually when we are upgrading components to use dropdown blocks we make the Abstract function
+    // the "true" function. But in this case I think it makes more sense to use the concret one.
+    RequestTranslation(languageToTranslateTo.toUnderlyingValue(), textToTranslate);
   }
 
   /**


### PR DESCRIPTION
### Description

Depends on #8 

Adds a dropdown for all of the languages that [Yandex supports](https://yandex.com/support/translate/supported-langs.html) (except for Elvish because I couldn't find a working country code).

### Testing

Tested that blocks get properly upgraded using this project.: [test12.zip](https://github.com/BeksOmega/appinventor-sources/files/5038160/test12.zip)

Tested that it can be used for translations. (It's actually really fun to pick options from the dropdown and try them out hehe).

### Recommended Method for Review

Commit-Wise
