### PR TITLE
Fix upgrading ScaleUnits

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/youngandroid/YoungAndroidFormUpgrader.java
@@ -1736,7 +1736,7 @@ public final class YoungAndroidFormUpgrader {
       srcCompVersion = 5;
     }
     if (srcCompVersion < 6) {
-      // Adds Units and MapType dropdowns.
+      // Adds ScaleUnits and MapType dropdowns.
       srcCompVersion = 6;
     }
     return srcCompVersion;

--- a/appinventor/blocklyeditor/src/versioning.js
+++ b/appinventor/blocklyeditor/src/versioning.js
@@ -2128,7 +2128,7 @@ Blockly.Versioning.AllUpgradeMaps =
     // AI2:
     // - Adds Units and MapType dropdowns.
     6: [Blockly.Versioning.makeSetterUseDropdown(
-          'Map', 'ScaleUnits', 'Units'),
+          'Map', 'ScaleUnits', 'ScaleUnits'),
         Blockly.Versioning.makeSetterUseDropdown(
           'Map', 'MapType', 'MapType')]
 

--- a/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
+++ b/appinventor/components/src/com/google/appinventor/components/common/YaVersion.java
@@ -1025,7 +1025,7 @@ public class YaVersion {
   // - Added ShowScale property
   // - Added ScaleUnits property
   // For MAP_COMPONENT_VERSION 6:
-  // - Adds Units and MapType dropdowns.
+  // - Adds ScaleUnits and MapType dropdowns.
   public static final int MAP_COMPONENT_VERSION = 6;
 
   // For MARKER_COMPONENT_VERSION 1:


### PR DESCRIPTION
### Description

When I renamed the map enum Units to ScaleUnits I forgot to fix the upgrader in versioning.js (gaaaah why past self) This PR fixes that issue.

Note that I did this correctly when I changed UltrasonicSensorMode to UltrasonicSensorUnit [here](https://github.com/BeksOmega/appinventor-sources/pull/21).

### Testing

Tested with this zipped aia: [test5.zip](https://github.com/BeksOmega/appinventor-sources/files/5125820/test5.zip)

And upgrading worked correctly.